### PR TITLE
change group from "backup" to "mantle"

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -13,7 +13,7 @@ resources:
     namespaced: true
   controller: true
   domain: cybozu.io
-  group: backup
+  group: mantle
   kind: MantleBackup
   path: github.com/cybozu-go/mantle/api/v1
   version: v1

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -1,4 +1,4 @@
-// Package v1 contains API Schema definitions for the backup v1 API group
+// Package v1 contains API Schema definitions for the mantle v1 API group
 // +kubebuilder:object:generate=true
 // +groupName=mantle.cybozu.io
 package v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	backupv1 "github.com/cybozu-go/mantle/api/v1"
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller"
 	//+kubebuilder:scaffold:imports
 )
@@ -30,7 +30,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(backupv1.AddToScheme(scheme))
+	utilruntime.Must(mantlev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	backupv1 "github.com/cybozu-go/mantle/api/v1"
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +35,7 @@ var _ = Describe("MantleBackup controller", func() {
 	storageClassName := dummyStorageClassName
 
 	BeforeEach(func() {
-		err := backupv1.AddToScheme(scheme)
+		err := mantlev1.AddToScheme(scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -118,12 +118,12 @@ var _ = Describe("MantleBackup controller", func() {
 		err = k8sClient.Status().Update(ctx, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 
-		backup := backupv1.MantleBackup{
+		backup := mantlev1.MantleBackup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backup",
 				Namespace: ns,
 			},
-			Spec: backupv1.MantleBackupSpec{
+			Spec: mantlev1.MantleBackupSpec{
 				PVC: pvc.Name,
 			},
 		}
@@ -164,7 +164,7 @@ var _ = Describe("MantleBackup controller", func() {
 				return err
 			}
 
-			if meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse).Status != metav1.ConditionTrue {
+			if meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse).Status != metav1.ConditionTrue {
 				return fmt.Errorf("not ready to use yet")
 			}
 
@@ -246,12 +246,12 @@ var _ = Describe("MantleBackup controller", func() {
 		err = k8sClient.Status().Update(ctx, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 
-		backup := backupv1.MantleBackup{
+		backup := mantlev1.MantleBackup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backup",
 				Namespace: ns,
 			},
-			Spec: backupv1.MantleBackupSpec{
+			Spec: mantlev1.MantleBackupSpec{
 				PVC: pvc.Name,
 			},
 		}
@@ -292,7 +292,7 @@ var _ = Describe("MantleBackup controller", func() {
 				return err
 			}
 
-			if meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse).Status != metav1.ConditionTrue {
+			if meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse).Status != metav1.ConditionTrue {
 				return fmt.Errorf("not ready to use yet")
 			}
 
@@ -313,7 +313,7 @@ var _ = Describe("MantleBackup controller", func() {
 				return err
 			}
 
-			condition := meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse)
+			condition := meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)
 			if condition == nil {
 				return fmt.Errorf("condition is not set")
 			}
@@ -382,12 +382,12 @@ var _ = Describe("MantleBackup controller", func() {
 		err = k8sClient.Status().Update(ctx, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 
-		backup := backupv1.MantleBackup{
+		backup := mantlev1.MantleBackup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backup",
 				Namespace: ns,
 			},
-			Spec: backupv1.MantleBackupSpec{
+			Spec: mantlev1.MantleBackupSpec{
 				PVC: pvc.Name,
 			},
 		}
@@ -404,11 +404,11 @@ var _ = Describe("MantleBackup controller", func() {
 				return err
 			}
 
-			condition := meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse)
+			condition := meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)
 			if condition == nil {
 				return fmt.Errorf("condition is not set")
 			}
-			if !(condition.Status == metav1.ConditionFalse && condition.Reason != backupv1.BackupReasonNone) {
+			if !(condition.Status == metav1.ConditionFalse && condition.Reason != mantlev1.BackupReasonNone) {
 				return fmt.Errorf("should not be ready to use")
 			}
 
@@ -420,12 +420,12 @@ var _ = Describe("MantleBackup controller", func() {
 		ctx := context.Background()
 		ns := createNamespace()
 
-		backup := backupv1.MantleBackup{
+		backup := mantlev1.MantleBackup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backup",
 				Namespace: ns,
 			},
-			Spec: backupv1.MantleBackupSpec{
+			Spec: mantlev1.MantleBackupSpec{
 				PVC: "non-existent-pvc",
 			},
 		}
@@ -442,11 +442,11 @@ var _ = Describe("MantleBackup controller", func() {
 				return err
 			}
 
-			condition := meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse)
+			condition := meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)
 			if condition == nil {
 				return fmt.Errorf("condition is not set")
 			}
-			if !(condition.Status == metav1.ConditionFalse && condition.Reason != backupv1.BackupReasonNone) {
+			if !(condition.Status == metav1.ConditionFalse && condition.Reason != mantlev1.BackupReasonNone) {
 				return fmt.Errorf("should not be ready to use")
 			}
 
@@ -510,12 +510,12 @@ var _ = Describe("MantleBackup controller", func() {
 		err = k8sClient.Status().Update(ctx, &pvc)
 		Expect(err).NotTo(HaveOccurred())
 
-		backup := backupv1.MantleBackup{
+		backup := mantlev1.MantleBackup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "backup",
 				Namespace: ns,
 			},
-			Spec: backupv1.MantleBackupSpec{
+			Spec: mantlev1.MantleBackupSpec{
 				PVC: pvc.Name,
 			},
 		}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -21,7 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	backupv1 "github.com/cybozu-go/mantle/api/v1"
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = backupv1.AddToScheme(scheme.Scheme)
+	err = mantlev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	backupv1 "github.com/cybozu-go/mantle/api/v1"
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -207,10 +207,10 @@ func (test *backupTest) testCase1() {
 		By("Checking that the status.conditions of the MantleBackup resource remain \"Bound\"")
 		stdout, _, err := kubectl("-n", test.tenantNamespace1, "get", "mantlebackup", test.mantleBackupName3, "-o", "json")
 		Expect(err).NotTo(HaveOccurred())
-		var backup backupv1.MantleBackup
+		var backup mantlev1.MantleBackup
 		err = yaml.Unmarshal(stdout, &backup)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(meta.FindStatusCondition(backup.Status.Conditions, backupv1.BackupConditionReadyToUse).Status).
+		Expect(meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse).Status).
 			To(Equal(metav1.ConditionTrue))
 	})
 


### PR DESCRIPTION
All resources related to Mantle should be created under mantle.cybozu.io. This means that the group is not "backup" but "mantle". This commit updates the group in PROJECT and replaces `backupv1` with `mantlev1`.