### PR TITLE
support shortname mb for MantleBackup

### DIFF
--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -48,6 +48,7 @@ const (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=mb
 
 // MantleBackup is the Schema for the mantlebackups API
 type MantleBackup struct {

--- a/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
+++ b/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: MantleBackup
     listKind: MantleBackupList
     plural: mantlebackups
+    shortNames:
+    - mb
     singular: mantlebackup
   scope: Namespaced
   versions:

--- a/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
+++ b/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: MantleBackup
     listKind: MantleBackupList
     plural: mantlebackups
+    shortNames:
+    - mb
     singular: mantlebackup
   scope: Namespaced
   versions:


### PR DESCRIPTION
A PR for KAIZEN. This PR allows users to use `mb` as a shortname of MantleBackup.