### PR TITLE
test/e2e: add the template of the test for mirroring

### DIFF
--- a/.github/actions/purge-unnecessary-deb-packages/action.yaml
+++ b/.github/actions/purge-unnecessary-deb-packages/action.yaml
@@ -1,0 +1,21 @@
+name: "Purge unnecessary deb packages"
+description: "This action purges unnecessary deb packages to overcome the lack of the storage capacity."
+inputs: {}
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: "Purge unnecessary deb packages"
+      shell: bash
+      run: |-
+           sudo apt-get purge -y apport apport-symptoms fwupd nano netplan.io popularity-contest unattended-upgrades update-manager-core snapd
+           sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
+           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup /usr/lib/jvm || true
+           sudo apt-get purge -y $(dpkg-query -W | grep nginx | awk '{print $1}')
+           sudo apt-get purge -y aria2 ansible azure-cli shellcheck rpm xorriso zsync firefox gfortran-9 google-chrome-stable google-cloud-sdk
+           sudo apt-get purge -y imagemagick libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional mercurial apt-transport-https
+           sudo apt-get purge -y mono-complete unixodbc-dev yarn chrpath libxft-dev libfreetype6-dev libfontconfig1 libfontconfig1-dev
+           sudo apt-get purge -y snmp pollinate libpq-dev postgresql-client powershell ruby-full sphinxsearch subversion azure-cli
+           sudo apt-get purge -y $(dpkg-query -W | grep dotnet | awk '{print $1}')
+           sudo apt-get autoremove -y >/dev/null 2>&1
+           sudo apt-get autoclean -y >/dev/null 2>&1

--- a/.github/actions/set-up-kvm-for-e2e-tests/action.yaml
+++ b/.github/actions/set-up-kvm-for-e2e-tests/action.yaml
@@ -1,0 +1,29 @@
+name: "Set up KVM for end-to-end tests"
+description: "This action sets up KVM for end-to-end tests. It purges lots of unnecessary deb packages, too."
+inputs: {}
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: "KVM setup"
+      shell: bash
+      run: |-
+           VIRTUALIZATION_SUPPORT=$(grep -E -q 'vmx|svm' /proc/cpuinfo && echo yes || echo no)
+           echo ${VIRTUALIZATION_SUPPORT}
+           if [ "${VIRTUALIZATION_SUPPORT}" != "yes" ]; then
+             echo "CPU does not support the virtualization feature."
+             exit 1
+           fi
+           sudo apt-get install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+           kvm-ok
+           sudo adduser `id -un` libvirt
+           sudo adduser `id -un` kvm
+           virsh list --all
+           sudo ls -la /var/run/libvirt/libvirt-sock
+           sudo chmod 777 /var/run/libvirt/libvirt-sock
+           sudo ls -la /var/run/libvirt/libvirt-sock
+           ls -l /dev/kvm
+           sudo rmmod kvm_amd
+           sudo rmmod kvm
+           sudo modprobe -a kvm
+           sudo modprobe -a kvm_amd

--- a/.github/workflows/e2e-multiple-k8s-clusters.yaml
+++ b/.github/workflows/e2e-multiple-k8s-clusters.yaml
@@ -1,4 +1,4 @@
-name: "e2e"
+name: "e2e-multiple-k8s-clusters"
 on:
   pull_request:
     paths-ignore:
@@ -11,9 +11,16 @@ on:
     branches:
       - "main"
 
+# Cancel any ongoing workflows on the same branch to avoid unnecessary fees.
+# cf. https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-and-the-default-behavior
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: "ubuntu-22.04"
+    #runs-on: "ubuntu-22.04"
+    runs-on: mantle_large_runner_16core
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -32,4 +39,4 @@ jobs:
           restore-keys: |
             go-
       - run: make -C test/e2e setup
-      - run: make -C test/e2e test
+      - run: make -C test/e2e test-multiple-k8s-clusters

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -22,6 +22,8 @@ POLLING_INTERVAL := 1
 TIMEOUT_SECS := 180
 LOOP_DEV := /dev/loop0
 LOOP_DEV2 := /dev/loop1
+MINIKUBE_PROFILE_PRIMARY=profile1
+MINIKUBE_PROFILE_SECONDARY=profile2
 
 export MINIKUBE_HOME
 
@@ -34,15 +36,25 @@ setup:
 
 .PHONY: test
 test:
-	$(MAKE) launch-minikube
-	$(MAKE) image-build
-	$(MAKE) launch-rook-ceph
-	$(MAKE) setup-components
+	$(MAKE) launch-cluster MINIKUBE_PROFILE=$(MINIKUBE_PROFILE_PRIMARY)
+	$(MINIKUBE) profile $(MINIKUBE_PROFILE_PRIMARY)
 	$(MAKE) do_test
+
+.PHONY: test-multiple-k8s-clusters
+test-multiple-k8s-clusters:
+	$(MAKE) launch-cluster MINIKUBE_PROFILE=$(MINIKUBE_PROFILE_PRIMARY)
+	$(MAKE) launch-cluster MINIKUBE_PROFILE=$(MINIKUBE_PROFILE_SECONDARY)
+	$(MINIKUBE) profile $(MINIKUBE_PROFILE_PRIMARY)
+	env \
+		MINIKUBE=$(MINIKUBE) \
+		MINIKUBE_HOME=$(MINIKUBE_HOME) \
+		MINIKUBE_PROFILE_PRIMARY=$(MINIKUBE_PROFILE_PRIMARY) \
+		MINIKUBE_PROFILE_SECONDARY=$(MINIKUBE_PROFILE_SECONDARY) \
+		./test-multiple-k8s-clusters.sh
 
 .PHONY: clean
 clean:
-	$(MAKE) delete-minikube
+	$(MINIKUBE) delete --all || true
 
 $(BINDIR):
 	mkdir -p $@
@@ -63,24 +75,25 @@ $(HELM): | $(BINDIR)
 	$(CURL) https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz \
 		| tar xvz -C $(BINDIR) --strip-components 1 linux-amd64/helm
 
-.PHONY: launch-minikube
-launch-minikube:
+.PHONY: launch-cluster
+launch-cluster: MINIKUBE_PROFILE=
+launch-cluster:
 	# TODO: Is there any better way to verify whether k8s cluster is available or not?
-	kubectl get pod >/dev/null 2>&1; \
-	RET=$$? ; \
-	if [ $$RET -eq 0 ] ; then exit; fi ; \
-	$(MINIKUBE) start \
-		--kubernetes-version="v$(KUBERNETES_VERSION)" \
-		--driver=kvm2 \
-		--memory 6g \
-		--cpus=2 \
-		--extra-config=kubeadm.node-name=$(NODE_NAME) \
-		--extra-config=kubelet.hostname-override=$(NODE_NAME)
-
-.PHONY: delete-minikube
-delete-minikube:
-	$(MINIKUBE) stop || true
-	$(MINIKUBE) delete || true
+	if $(MINIKUBE) profile $(MINIKUBE_PROFILE) |& grep "not found" > /dev/null; then \
+		$(MINIKUBE) start \
+			--kubernetes-version="v$(KUBERNETES_VERSION)" \
+			--driver=kvm2 \
+			--memory 6g \
+			--cpus=2 \
+			--extra-config=kubeadm.node-name=$(NODE_NAME) \
+			--extra-config=kubelet.hostname-override=$(NODE_NAME) \
+			--network mantle-test \
+			-p $(MINIKUBE_PROFILE) ; \
+	fi
+	$(MINIKUBE) profile $(MINIKUBE_PROFILE)
+	$(MAKE) image-build
+	$(MAKE) launch-rook-ceph
+	$(MAKE) setup-components
 
 .PHONY: create-loop-dev
 create-loop-dev:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,31 @@
+# End-to-End Tests for Mantle
+
+## Requirements
+
+To set up the test environment, you'll need Minikube with the KVM2 driver enabled, so make sure to enable KVM2 beforehand. Don't worry about installing Minikube yourself; it will be installed automatically.
+
+## Usage
+
+First, install the necessary software by running:
+```
+cd test/e2e
+make setup
+```
+
+Next, you can start the tests:
+
+- To run the tests using a single Kubernetes cluster:
+    ```
+    make test
+    ```
+- To run the tests using multiple Kubernetes clusters:
+    ```
+    make test-multiple-k8s-clusters
+    ```
+
+These Makefile targets are designed to be idempotent, so if you need to re-run the tests after making changes to the code, simply run the appropriate target again.
+
+Finally, to clean up your environment, run:
+```
+make clean
+```

--- a/test/e2e/test-multiple-k8s-clusters.sh
+++ b/test/e2e/test-multiple-k8s-clusters.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash -xeu
+
+set -o pipefail
+
+# Exits with an "unbound variable" error if one of the following environment
+# variables is undefined, thanks to "-u" option to bash.
+echo "${MINIKUBE}"
+echo "${MINIKUBE_HOME}"
+echo "${MINIKUBE_PROFILE_PRIMARY}"
+echo "${MINIKUBE_PROFILE_SECONDARY}"
+
+cat <<EOS | ${MINIKUBE} -p ${MINIKUBE_PROFILE_PRIMARY} kubectl -- apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.27.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  type: NodePort
+  ports:
+  - port: 8080
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: nginx
+EOS
+${MINIKUBE} -p ${MINIKUBE_PROFILE_PRIMARY} kubectl -- wait --for=jsonpath='{.status.readyReplicas}'=1 deploy/nginx
+
+${MINIKUBE} service list -p ${MINIKUBE_PROFILE_PRIMARY}
+URL=$(${MINIKUBE} service list -p ${MINIKUBE_PROFILE_PRIMARY} -o json | jq -r '.[].URLs | select(. | length > 0)[]' | head -1)
+
+# Exits with an errornous exit code if curl fails, thanks to "-e" option to bash.
+${MINIKUBE} -p ${MINIKUBE_PROFILE_SECONDARY} kubectl -- exec -it -n rook-ceph deploy/rook-ceph-tools -- curl -vvv ${URL} > /dev/null


### PR DESCRIPTION
We're currently working on mirroring feature. To develop this feature, we need multiple K8s clusters for testing.

This PR makes it easier to deploy multiple K8s clusters for testing purposes. Each K8s cluster has its own Rook/Ceph setup and is connected to the same network, allowing them to communicate with each other.

We've also added a new GHA workflow to test the multiple K8s clusters. At the moment, we don't have a comprehensive test suite that uses the multiple clusters. Instead, we deploy an Nginx server on one cluster and use curl from another cluster to query the server, ensuring that the clusters are functioning correctly.
