### PR TITLE
Change MB expire strategy

### DIFF
--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -19,6 +19,13 @@ type MantleBackupSpec struct {
 	// 'namespace' specifies backup target Namespace
 	// +kubebuilder:validation:Required
 	Namespace string `json:"namespace,omitempty"`
+
+	// NOTE: we CANNOT use metav1.Duration for Expire due to an unresolved k8s bug.
+	// See https://github.com/kubernetes/apiextensions-apiserver/issues/56 for the details.
+
+	// 'expire' specifies the expiration duration of the backup
+	//+kubebuilder:validation:Format:="duration"
+	Expire string `json:"expire,omitempty"`
 }
 
 // MantleBackupStatus defines the observed state of MantleBackup

--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -25,7 +25,10 @@ type MantleBackupSpec struct {
 
 	// 'expire' specifies the expiration duration of the backup
 	//+kubebuilder:validation:Format:="duration"
-	Expire string `json:"expire,omitempty"`
+	//+kubebuilder:validation:XValidation:message="expire must be >= 1d",rule="self >= duration('24h')"
+	//+kubebuilder:validation:XValidation:message="expire must be <= 15d",rule="self <= duration('360h')"
+	//+kubebuilder:validation:XValidation:message="spec.expire is immutable",rule="self == oldSelf"
+	Expire string `json:"expire"`
 }
 
 // MantleBackupStatus defines the observed state of MantleBackup

--- a/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
+++ b/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
@@ -46,12 +46,21 @@ spec:
                   backup'
                 format: duration
                 type: string
+                x-kubernetes-validations:
+                - message: expire must be >= 1d
+                  rule: self >= duration('24h')
+                - message: expire must be <= 15d
+                  rule: self <= duration('360h')
+                - message: spec.expire is immutable
+                  rule: self == oldSelf
               namespace:
                 description: '''namespace'' specifies backup target Namespace'
                 type: string
               pvc:
                 description: '''pvc'' specifies backup target PVC'
                 type: string
+            required:
+            - expire
             type: object
           status:
             description: MantleBackupStatus defines the observed state of MantleBackup

--- a/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
+++ b/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
@@ -41,6 +41,11 @@ spec:
           spec:
             description: MantleBackupSpec defines the desired state of MantleBackup
             properties:
+              expire:
+                description: '''expire'' specifies the expiration duration of the
+                  backup'
+                format: duration
+                type: string
               namespace:
                 description: '''namespace'' specifies backup target Namespace'
                 type: string

--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -64,9 +64,6 @@ spec:
             {{- with .Values.controller.mantleServiceEndpoint }}
             - --mantle-service-endpoint={{ . }}
             {{- end }}
-            {{- with .Values.controller.expireOffset }}
-            - --expire-offset={{ . }}
-            {{- end }}
             {{- with .Values.controller.overwriteMBCSchedule }}
             - --overwrite-mbc-schedule={{ . }}
             {{- end }}

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -1,4 +1,4 @@
-package backupandrotate
+package backup
 
 import (
 	"context"
@@ -8,16 +8,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/kube-openapi/pkg/validation/strfmt"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -29,16 +26,14 @@ import (
 
 var (
 	mbcName, mbcNamespace string
-	expireOffset          string
 	zapOpts               zap.Options
 
 	scheme                = runtime.NewScheme()
 	MantleBackupConfigUID = "mantle.cybozu.io/mbc-uid"
-	MantleRetainIfExpired = "mantle.cybozu.io/retainIfExpired"
-	logger                = ctrl.Log.WithName("backup-and-rotate")
+	logger                = ctrl.Log.WithName("backup")
 
-	BackupAndRotateCmd = &cobra.Command{
-		Use: "backup-and-rotate",
+	BackupCmd = &cobra.Command{
+		Use: "backup",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return subMain(cmd.Context())
 		},
@@ -46,12 +41,9 @@ var (
 )
 
 func init() {
-	flags := BackupAndRotateCmd.Flags()
+	flags := BackupCmd.Flags()
 	flags.StringVar(&mbcName, "name", "", "MantleBackupConfig resource's name")
 	flags.StringVar(&mbcNamespace, "namespace", "", "MantleBackupConfig resource's namespace")
-	flags.StringVar(&expireOffset, "expire-offset", "0s",
-		"An offset for MantleBackupConfig's .spec.expire field. A MantleBackup will expire after "+
-			"it has been active for (.spec.expire - expire-offset) time. This option is intended for testing purposes only.")
 
 	goflags := flag.NewFlagSet("goflags", flag.ExitOnError)
 	zapOpts.Development = true
@@ -91,11 +83,6 @@ func fetchJobID() (string, error) {
 func subMain(ctx context.Context) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
-	parsedExpireOffset, err := strfmt.ParseDuration(expireOffset)
-	if err != nil {
-		return fmt.Errorf("couldn't parse the expire offset: %w", err)
-	}
-
 	cli, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("couldn't create a new client: %w", err)
@@ -109,10 +96,6 @@ func subMain(ctx context.Context) error {
 
 	if err := createMantleBackup(ctx, cli, &mbc); err != nil {
 		return fmt.Errorf("backup failed: %s: %s: %w", mbcName, mbcNamespace, err)
-	}
-
-	if err := rotateMantleBackup(ctx, cli, &mbc, parsedExpireOffset); err != nil {
-		return fmt.Errorf("rotation failed: %s: %s: %w", mbcName, mbcNamespace, err)
 	}
 
 	return nil
@@ -168,64 +151,5 @@ func createMantleBackup(ctx context.Context, cli client.Client, mbc *mantlev1.Ma
 	logger.Info("MantleBackup already exists",
 		"mbName", mbName, "mbNamespace", mbNamespace,
 		"mbcName", mbcName, "mbcNamespace", mbcNamespace)
-	return nil
-}
-
-func rotateMantleBackup(
-	ctx context.Context,
-	cli client.Client,
-	mbc *mantlev1.MantleBackupConfig,
-	expireOffset time.Duration,
-) error {
-	// List all MantleBackup objects associated with the mbc.
-	var mbList mantlev1.MantleBackupList
-	if err := cli.List(ctx, &mbList, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{MantleBackupConfigUID: string(mbc.GetUID())}),
-	}); err != nil {
-		return fmt.Errorf("couldn't list MantleBackups: %s: %w", string(mbc.UID), err)
-	}
-
-	// Delete the MantleBackup objects that are already expired and don't have the retainIfExpired label.
-	expire, err := strfmt.ParseDuration(mbc.Spec.Expire)
-	if err != nil {
-		return fmt.Errorf("couldn't parse spec.expire: %s: %w", mbc.Spec.Expire, err)
-	}
-	if expire >= expireOffset {
-		expire -= expireOffset
-	} else {
-		expire = 0
-	}
-	for _, mb := range mbList.Items {
-		if mb.Status.CreatedAt == (metav1.Time{}) {
-			// mb is not created yet (at least from the cache's perspective), so let's ignore it.
-			continue
-		}
-		elapsed := time.Since(mb.Status.CreatedAt.Time)
-		if elapsed <= expire {
-			continue
-		}
-		retain, ok := mb.GetAnnotations()[MantleRetainIfExpired]
-		if ok && retain == "true" {
-			continue
-		}
-
-		if err := cli.Delete(ctx, &mb, &client.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID:             &mb.UID,
-				ResourceVersion: &mb.ResourceVersion,
-			},
-		}); err == nil || errors.IsNotFound(err) {
-			logger.Info("MantleBackup deleted",
-				"mb.Name", mb.Name, "mb.Namespace", mb.Namespace,
-				"mb.UID", mb.UID, "mb.ResourceVersion", mb.ResourceVersion,
-				"mbcName", mbcName, "mbcNamespace", mbcNamespace,
-				"elapsed", elapsed, "expire", expire,
-			)
-		} else {
-			return fmt.Errorf("couldn't delete MantleBackup: %s: %s: %s: %s: %w",
-				mb.Name, mb.Namespace, mb.UID, mb.ResourceVersion, err)
-		}
-	}
-
 	return nil
 }

--- a/cmd/backupandrotate/main.go
+++ b/cmd/backupandrotate/main.go
@@ -136,7 +136,8 @@ func createMantleBackup(ctx context.Context, cli client.Client, mbc *mantlev1.Ma
 			Labels:    map[string]string{MantleBackupConfigUID: string(mbc.GetUID())},
 		},
 		Spec: mantlev1.MantleBackupSpec{
-			PVC: mbc.Spec.PVC,
+			Expire: mbc.Spec.Expire,
+			PVC:    mbc.Spec.PVC,
 		},
 	})
 	if err == nil {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -46,7 +46,6 @@ var (
 	enableLeaderElection  bool
 	probeAddr             string
 	zapOpts               zap.Options
-	expireOffset          string
 	overwriteMBCSchedule  string
 	role                  string
 	mantleServiceEndpoint string
@@ -62,9 +61,6 @@ func init() {
 	flags.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flags.StringVar(&expireOffset, "expire-offset", "",
-		"An offset for MantleBackupConfig's .spec.expire field. A MantleBackup will expire after "+
-			"it has been active for (.spec.expire - expire-offset) time. This option is intended for testing purposes only.")
 	flags.StringVar(&overwriteMBCSchedule, "overwrite-mbc-schedule", "",
 		"By setting this option, every CronJob created by this controller for every MantleBackupConfig "+
 			"will use its value as .spec.schedule. This option is intended for testing purposes only.")
@@ -142,7 +138,6 @@ func setupReconcilers(mgr manager.Manager, primarySettings *controller.PrimarySe
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		managedCephClusterID,
-		expireOffset,
 		overwriteMBCSchedule,
 		role,
 	).SetupWithManager(mgr); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/cybozu-go/mantle/cmd/backupandrotate"
+	"github.com/cybozu-go/mantle/cmd/backup"
 	"github.com/cybozu-go/mantle/cmd/controller"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +13,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(backupandrotate.BackupAndRotateCmd)
+	rootCmd.AddCommand(backup.BackupCmd)
 	rootCmd.AddCommand(controller.ControllerCmd)
 }
 

--- a/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
+++ b/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
@@ -46,12 +46,21 @@ spec:
                   backup'
                 format: duration
                 type: string
+                x-kubernetes-validations:
+                - message: expire must be >= 1d
+                  rule: self >= duration('24h')
+                - message: expire must be <= 15d
+                  rule: self <= duration('360h')
+                - message: spec.expire is immutable
+                  rule: self == oldSelf
               namespace:
                 description: '''namespace'' specifies backup target Namespace'
                 type: string
               pvc:
                 description: '''pvc'' specifies backup target PVC'
                 type: string
+            required:
+            - expire
             type: object
           status:
             description: MantleBackupStatus defines the observed state of MantleBackup

--- a/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
+++ b/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
@@ -41,6 +41,11 @@ spec:
           spec:
             description: MantleBackupSpec defines the desired state of MantleBackup
             properties:
+              expire:
+                description: '''expire'' specifies the expiration duration of the
+                  backup'
+                format: duration
+                type: string
               namespace:
                 description: '''namespace'' specifies backup target Namespace'
                 type: string

--- a/internal/ceph/ceph.go
+++ b/internal/ceph/ceph.go
@@ -1,9 +1,36 @@
 package ceph
 
+import (
+	"strings"
+	"time"
+)
+
 type RBDInfo struct {
 	ParentPool  string
 	ParentImage string
 	ParentSnap  string
+}
+
+type RBDTimeStamp struct {
+	time.Time
+}
+
+func NewRBDTimeStamp(t time.Time) RBDTimeStamp {
+	return RBDTimeStamp{t}
+}
+
+func (t *RBDTimeStamp) UnmarshalJSON(data []byte) error {
+	var err error
+	t.Time, err = time.Parse("Mon Jan  2 15:04:05 2006", strings.Trim(string(data), `"`))
+	return err
+}
+
+type RBDSnapshot struct {
+	Id        int          `json:"id,omitempty"`
+	Name      string       `json:"name,omitempty"`
+	Size      int          `json:"size,omitempty"`
+	Protected bool         `json:"protected,string,omitempty"`
+	Timestamp RBDTimeStamp `json:"timestamp,omitempty"`
 }
 
 type CephCmd interface {
@@ -11,6 +38,9 @@ type CephCmd interface {
 	RBDInfo(pool, image string) (*RBDInfo, error)
 	RBDLs(pool string) ([]string, error)
 	RBDRm(pool, image string) error
+	RBDSnapCreate(pool, image, snap string) error
+	RBDSnapLs(pool, image string) ([]RBDSnapshot, error)
+	RBDSnapRm(pool, image, snap string) error
 }
 
 type cephCmdImpl struct {

--- a/internal/ceph/rbd.go
+++ b/internal/ceph/rbd.go
@@ -81,3 +81,39 @@ func (c *cephCmdImpl) RBDRm(pool, image string) error {
 
 	return nil
 }
+
+// RBDSnapCreate creates an RBD snapshot.
+func (c *cephCmdImpl) RBDSnapCreate(pool, image, snap string) error {
+	_, err := c.command.execute("rbd", "snap", "create", fmt.Sprintf("%s/%s@%s", pool, image, snap))
+	if err != nil {
+		return fmt.Errorf("failed to create RBD snapshot: %v", err)
+	}
+
+	return nil
+}
+
+// RBDSnapLs lists RBD snapshots of an image.
+func (c *cephCmdImpl) RBDSnapLs(pool, image string) ([]RBDSnapshot, error) {
+	out, err := c.command.execute("rbd", "snap", "ls", "--format", "json", fmt.Sprintf("%s/%s", pool, image))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list RBD snapshots: %v", err)
+	}
+
+	var snapshots []RBDSnapshot
+	err = json.Unmarshal(out, &snapshots)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal RBD snapshots: %v", err)
+	}
+
+	return snapshots, nil
+}
+
+// RBDSnapRm removes an RBD snapshot.
+func (c *cephCmdImpl) RBDSnapRm(pool, image, snap string) error {
+	_, err := c.command.execute("rbd", "snap", "rm", fmt.Sprintf("%s/%s@%s", pool, image, snap))
+	if err != nil {
+		return fmt.Errorf("failed to remove RBD snapshot: %v", err)
+	}
+
+	return nil
+}

--- a/internal/ceph/util.go
+++ b/internal/ceph/util.go
@@ -1,0 +1,28 @@
+package ceph
+
+import (
+	"errors"
+	"slices"
+)
+
+var ErrSnapshotNotFound = errors.New("snapshot not found")
+
+func IsRBDSnapshotNamed(name string) func(RBDSnapshot) bool {
+	return func(s RBDSnapshot) bool {
+		return s.Name == name
+	}
+}
+
+func FindRBDSnapshot(cmd CephCmd, pool, image, snap string) (*RBDSnapshot, error) {
+	snaps, err := cmd.RBDSnapLs(pool, image)
+	if err != nil {
+		return nil, err
+	}
+
+	i := slices.IndexFunc(snaps, IsRBDSnapshotNamed(snap))
+	if i == -1 {
+		return nil, ErrSnapshotNotFound
+	}
+
+	return &snaps[i], nil
+}

--- a/internal/controller/internal/testutil/fake_rbd.go
+++ b/internal/controller/internal/testutil/fake_rbd.go
@@ -1,0 +1,79 @@
+package testutil
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/cybozu-go/mantle/internal/ceph"
+)
+
+type fakeRBD struct {
+	nextSnapId int
+	snapshots  map[string][]ceph.RBDSnapshot
+}
+
+var _ ceph.CephCmd = &fakeRBD{}
+
+func NewFakeRBD() ceph.CephCmd {
+	return &fakeRBD{
+		nextSnapId: 0,
+		snapshots:  make(map[string][]ceph.RBDSnapshot),
+	}
+}
+
+func (f *fakeRBD) RBDClone(pool, srcImage, srcSnap, dstImage, features string) error {
+	return nil
+}
+
+func (f *fakeRBD) RBDInfo(pool, image string) (*ceph.RBDInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeRBD) RBDLs(pool string) ([]string, error) {
+	return nil, nil
+}
+
+func (f *fakeRBD) RBDRm(pool, image string) error {
+	return nil
+}
+
+func (f *fakeRBD) RBDSnapCreate(pool, image, snap string) error {
+	key := pool + "/" + image
+
+	snaps := f.snapshots[key]
+
+	if slices.ContainsFunc(snaps, ceph.IsRBDSnapshotNamed(snap)) {
+		return fmt.Errorf("snap already exists: %s@%s", key, snap)
+	}
+
+	f.snapshots[key] = append(snaps, ceph.RBDSnapshot{
+		Id:        f.nextSnapId,
+		Name:      snap,
+		Size:      10,
+		Protected: false,
+		Timestamp: ceph.NewRBDTimeStamp(time.Now().UTC()),
+	})
+
+	f.nextSnapId++
+
+	return nil
+}
+
+func (f *fakeRBD) RBDSnapLs(pool, image string) ([]ceph.RBDSnapshot, error) {
+	return f.snapshots[pool+"/"+image], nil
+}
+
+func (f *fakeRBD) RBDSnapRm(pool, image, snap string) error {
+	key := pool + "/" + image
+
+	snaps := f.snapshots[key]
+
+	if !slices.ContainsFunc(snaps, ceph.IsRBDSnapshotNamed(snap)) {
+		return fmt.Errorf("snap not found: %s@%s", key, snap)
+	}
+
+	f.snapshots[key] = slices.DeleteFunc(snaps, ceph.IsRBDSnapshotNamed(snap))
+
+	return nil
+}

--- a/internal/controller/internal/testutil/fake_rbd_test.go
+++ b/internal/controller/internal/testutil/fake_rbd_test.go
@@ -1,0 +1,49 @@
+package testutil
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FakeRBD", func() {
+	It("should create/list/rm a snapshot", func() {
+		f := NewFakeRBD()
+
+		By("checking creating a snapshot succeeds")
+		err := f.RBDSnapCreate("pool", "image", "snap1")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking creating the same snapshot fails")
+		err = f.RBDSnapCreate("pool", "image", "snap1")
+		Expect(err).To(HaveOccurred())
+
+		By("checking creating another snapshot succeeds")
+		err = f.RBDSnapCreate("pool", "image", "snap2")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking listing snapshots succeeds")
+		snaps, err := f.RBDSnapLs("pool", "image")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(snaps).To(ConsistOf(
+			HaveField("Name", "snap1"),
+			HaveField("Name", "snap2"),
+		))
+
+		By("checking removing a snapshot succeeds")
+		err = f.RBDSnapRm("pool", "image", "snap1")
+		Expect(err).ToNot(HaveOccurred())
+		snaps, err = f.RBDSnapLs("pool", "image")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(snaps).To(ConsistOf(
+			HaveField("Name", "snap2"),
+		))
+
+		By("checking removing the same snapshot fails")
+		err = f.RBDSnapRm("pool", "image", "snap1")
+		Expect(err).To(HaveOccurred())
+
+		By("checking removing another snapshot succeeds")
+		err = f.RBDSnapRm("pool", "image", "snap2")
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/internal/controller/internal/testutil/resources.go
+++ b/internal/controller/internal/testutil/resources.go
@@ -26,7 +26,7 @@ type ResourceManager struct {
 	client           client.Client
 	ClusterID        string
 	StorageClassName string
-	poolName         string
+	PoolName         string
 }
 
 func NewResourceManager(client client.Client) *ResourceManager {
@@ -34,7 +34,7 @@ func NewResourceManager(client client.Client) *ResourceManager {
 		client:           client,
 		StorageClassName: util.GetUniqueName("sc-"),
 		ClusterID:        util.GetUniqueName("ceph-"),
-		poolName:         util.GetUniqueName("pool-"),
+		PoolName:         util.GetUniqueName("pool-"),
 	}
 }
 
@@ -94,8 +94,8 @@ func (r *ResourceManager) createPVAndPVC(ctx context.Context, ns, pvName, pvcNam
 						"imageFeatures":                    "layering",
 						"imageFormat":                      "2",
 						"imageName":                        util.GetUniqueName("image-"),
-						"journalPool":                      r.poolName,
-						"pool":                             r.poolName,
+						"journalPool":                      r.PoolName,
+						"pool":                             r.PoolName,
 						"storage.kubernetes.io/csiProvisionerIdentity": "dummy",
 					},
 					VolumeHandle: "dummy",

--- a/internal/controller/internal/testutil/suite_test.go
+++ b/internal/controller/internal/testutil/suite_test.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Testutils Suite")
+}

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -49,14 +49,6 @@ type MantleBackupReconciler struct {
 	expireQueueCh        chan event.GenericEvent
 }
 
-type Snapshot struct {
-	Id        int    `json:"id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Size      int    `json:"size,omitempty"`
-	Protected bool   `json:"protected,string,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
-}
-
 // NewMantleBackupReconciler returns NodeReconciler.
 func NewMantleBackupReconciler(client client.Client, scheme *runtime.Scheme, managedCephClusterID, role string, primarySettings *PrimarySettings) *MantleBackupReconciler {
 	return &MantleBackupReconciler{

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -35,6 +35,7 @@ const (
 	labelRemoteBackupTargetPVCUID = "mantle.cybozu.io/remote-backup-target-pvc-uid"
 	annotRemoteUID                = "mantle.cybozu.io/remote-uid"
 	annotDiffTo                   = "mantle.cybozu.io/diff-to"
+	annotRetainIfExpired          = "mantle.cybozu.io/retain-if-expired"
 )
 
 // MantleBackupReconciler reconciles a MantleBackup object
@@ -237,6 +238,12 @@ func (r *MantleBackupReconciler) expire(ctx context.Context, backup *mantlev1.Ma
 	logger := log.FromContext(ctx)
 	if backup.Status.CreatedAt.IsZero() {
 		// the RBD snapshot has not be taken yet, do nothing.
+		return nil
+	}
+
+	if v, ok := backup.Annotations[annotRetainIfExpired]; ok && v == "true" {
+		// retain this backup.
+		// If the annotation is deleted, reconciliation will run, so no need to schedule.
 		return nil
 	}
 

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -22,6 +22,7 @@ import (
 var _ = Describe("MantleBackup controller", func() {
 	var mgrUtil testutil.ManagerUtil
 	var reconciler *MantleBackupReconciler
+	var ns string
 
 	// Not to access backup.Name before created, set the pointer to an empty object.
 	backup := &mantlev1.MantleBackup{}
@@ -77,6 +78,8 @@ var _ = Describe("MantleBackup controller", func() {
 
 		mgrUtil.Start()
 		time.Sleep(100 * time.Millisecond)
+
+		ns = resMgr.CreateNamespace()
 	})
 
 	AfterEach(func() {
@@ -85,8 +88,6 @@ var _ = Describe("MantleBackup controller", func() {
 	})
 
 	It("should be ready to use", func(ctx SpecContext) {
-		ns := resMgr.CreateNamespace()
-
 		pv, pvc, err := resMgr.CreateUniquePVAndPVC(ctx, ns)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -121,8 +122,6 @@ var _ = Describe("MantleBackup controller", func() {
 	})
 
 	It("should still be ready to use even if the PVC lost", func(ctx SpecContext) {
-		ns := resMgr.CreateNamespace()
-
 		_, pvc, err := resMgr.CreateUniquePVAndPVC(ctx, ns)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -140,8 +139,6 @@ var _ = Describe("MantleBackup controller", func() {
 	})
 
 	It("should not be ready to use if the PVC is the lost state from the beginning", func(ctx SpecContext) {
-		ns := resMgr.CreateNamespace()
-
 		pv, pvc, err := resMgr.CreateUniquePVAndPVC(ctx, ns)
 		Expect(err).NotTo(HaveOccurred())
 		pv.Status.Phase = corev1.VolumeAvailable
@@ -158,8 +155,6 @@ var _ = Describe("MantleBackup controller", func() {
 	})
 
 	It("should not be ready to use if specified non-existent PVC name", func(ctx SpecContext) {
-		ns := resMgr.CreateNamespace()
-
 		var err error
 		backup, err = resMgr.CreateUniqueBackupFor(ctx, &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -173,8 +168,6 @@ var _ = Describe("MantleBackup controller", func() {
 	})
 
 	It("should fail the resource creation the second time if the same MantleBackup is created twice", func(ctx SpecContext) {
-		ns := resMgr.CreateNamespace()
-
 		_, pvc, err := resMgr.CreateUniquePVAndPVC(ctx, ns)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/mantlebackupconfig_controller.go
+++ b/internal/controller/mantlebackupconfig_controller.go
@@ -33,7 +33,6 @@ type MantleBackupConfigReconciler struct {
 	Client               client.Client
 	Scheme               *runtime.Scheme
 	managedCephClusterID string
-	expireOffset         string
 	overwriteMBCSchedule string
 	role                 string
 }
@@ -42,11 +41,10 @@ func NewMantleBackupConfigReconciler(
 	cli client.Client,
 	scheme *runtime.Scheme,
 	managedCephClusterID string,
-	expireOffset string,
 	overwriteMBCSchedule string,
 	role string,
 ) *MantleBackupConfigReconciler {
-	return &MantleBackupConfigReconciler{cli, scheme, managedCephClusterID, expireOffset, overwriteMBCSchedule, role}
+	return &MantleBackupConfigReconciler{cli, scheme, managedCephClusterID, overwriteMBCSchedule, role}
 }
 
 //+kubebuilder:rbac:groups=mantle.cybozu.io,resources=mantlebackupconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -227,14 +225,13 @@ func (r *MantleBackupConfigReconciler) createOrUpdateCronJob(ctx context.Context
 			podSpec.Containers = append(podSpec.Containers, corev1.Container{})
 		}
 		container := &podSpec.Containers[0]
-		container.Name = "backup-and-rotate"
+		container.Name = "backup"
 		container.Image = image
 		container.Command = []string{
 			"/manager",
-			"backup-and-rotate",
+			"backup",
 			"--name", mbc.GetName(),
 			"--namespace", mbc.GetNamespace(),
-			"--expire-offset", r.expireOffset,
 		}
 		container.ImagePullPolicy = corev1.PullIfNotPresent
 		container.Env = []corev1.EnvVar{

--- a/internal/controller/mantlebackupconfig_controller_test.go
+++ b/internal/controller/mantlebackupconfig_controller_test.go
@@ -67,7 +67,6 @@ var _ = Describe("MantleBackupConfig controller", func() {
 			mgrUtil.GetManager().GetClient(),
 			mgrUtil.GetManager().GetScheme(),
 			resMgr.ClusterID,
-			"0s",
 			"",
 			RoleStandalone,
 		)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,9 +1,7 @@
 package controller
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -78,11 +76,6 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	resMgr = testutil.NewResourceManager(k8sClient)
 	err = resMgr.CreateStorageClass(ctx)
 	Expect(err).NotTo(HaveOccurred())
-
-	By("Assign noop executeCommand")
-	executeCommand = func(_ context.Context, _ []string, _ io.Reader) ([]byte, error) {
-		return nil, nil
-	}
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/multik8s/testdata/mantlebackup-template.yaml
+++ b/test/e2e/multik8s/testdata/mantlebackup-template.yaml
@@ -11,3 +11,4 @@ metadata:
   namespace: %s
 spec:
   pvc: %s
+  expire: "1d"

--- a/test/e2e/singlek8s/testdata/mantlebackup-template.yaml
+++ b/test/e2e/singlek8s/testdata/mantlebackup-template.yaml
@@ -11,3 +11,4 @@ metadata:
   namespace: %s
 spec:
   pvc: %s
+  expire: "1d"

--- a/test/e2e/testdata/values-mantle1.yaml
+++ b/test/e2e/testdata/values-mantle1.yaml
@@ -1,3 +1,2 @@
 controller:
-  expireOffset: 1w6d23h59m50s # 2w - 10s
   overwriteMBCSchedule: "* * * * *"


### PR DESCRIPTION
We designed MBC to handle the expiration of backups, but it is not good because MBC does not delete secondary MB if the network connection is disconnected. To fix this, we add an expire field to MB.