### PR TITLE
Use reader to check resources existence

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -128,6 +128,7 @@ func setupReconcilers(mgr manager.Manager, primarySettings *controller.PrimarySe
 
 	restoreReconciler := controller.NewMantleRestoreReconciler(
 		mgr.GetClient(),
+		mgr.GetAPIReader(),
 		mgr.GetScheme(),
 		managedCephClusterID,
 		role,

--- a/internal/controller/internal/testutil/manager_util.go
+++ b/internal/controller/internal/testutil/manager_util.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -16,8 +15,6 @@ type ManagerUtil interface {
 	Start()
 	Stop() error
 	GetManager() manager.Manager
-	GetScheme() *runtime.Scheme
-	GetClient() client.Client
 }
 
 type managerUtilImpl struct {
@@ -61,12 +58,4 @@ func (m *managerUtilImpl) Stop() error {
 
 func (m *managerUtilImpl) GetManager() manager.Manager {
 	return m.mgr
-}
-
-func (m *managerUtilImpl) GetScheme() *runtime.Scheme {
-	return m.mgr.GetScheme()
-}
-
-func (m *managerUtilImpl) GetClient() client.Client {
-	return m.mgr.GetClient()
 }

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -58,7 +58,13 @@ var _ = Describe("MantleBackup controller", func() {
 	BeforeEach(func() {
 		mgrUtil = testutil.NewManagerUtil(context.Background(), cfg, scheme.Scheme)
 
-		reconciler = NewMantleBackupReconciler(mgrUtil.GetClient(), mgrUtil.GetScheme(), resMgr.ClusterID, RoleStandalone, nil)
+		reconciler = NewMantleBackupReconciler(
+			mgrUtil.GetManager().GetClient(),
+			mgrUtil.GetManager().GetScheme(),
+			resMgr.ClusterID,
+			RoleStandalone,
+			nil,
+		)
 		err := reconciler.SetupWithManager(mgrUtil.GetManager())
 		Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/mantlebackupconfig_controller_test.go
+++ b/internal/controller/mantlebackupconfig_controller_test.go
@@ -63,7 +63,14 @@ var _ = Describe("MantleBackupConfig controller", func() {
 	BeforeEach(func() {
 		mgrUtil = testutil.NewManagerUtil(context.Background(), cfg, scheme.Scheme)
 
-		reconciler = NewMantleBackupConfigReconciler(mgrUtil.GetClient(), mgrUtil.GetScheme(), resMgr.ClusterID, "0s", "", RoleStandalone)
+		reconciler = NewMantleBackupConfigReconciler(
+			mgrUtil.GetManager().GetClient(),
+			mgrUtil.GetManager().GetScheme(),
+			resMgr.ClusterID,
+			"0s",
+			"",
+			RoleStandalone,
+		)
 		err := reconciler.SetupWithManager(mgrUtil.GetManager())
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
The client from Manager.GetClient() updates api-server directly but reads from its cache, therefore, we may oversight a resource just after its creation. This is harmful when we check a resouce has been deleted before some other clean up.