### PR TITLE
Fix nil pointer access violation

### DIFF
--- a/internal/controller/mantlerestore_controller.go
+++ b/internal/controller/mantlerestore_controller.go
@@ -88,8 +88,7 @@ func (r *MantleRestoreReconciler) restore(ctx context.Context, logger *slog.Logg
 	logger.Info("restoring", "name", restore.Name, "namespace", restore.Namespace, "backup", restore.Spec.Backup)
 
 	// skip if already ReadyToUse
-	condition := meta.FindStatusCondition(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)
-	if condition != nil && condition.Status == metav1.ConditionTrue {
+	if meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse) {
 		return ctrl.Result{}, nil
 	}
 
@@ -136,8 +135,7 @@ func (r *MantleRestoreReconciler) restore(ctx context.Context, logger *slog.Logg
 	}
 
 	// check if the backup is ReadyToUse
-	condition = meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)
-	if condition == nil || condition.Status != metav1.ConditionTrue {
+	if !meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
 		logger.Info("backup is not ready to use", "backup", backup.Name, "namespace", backup.Namespace)
 		return ctrl.Result{Requeue: true}, nil
 	}

--- a/test/e2e/multik8s/suite_test.go
+++ b/test/e2e/multik8s/suite_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMtest(t *testing.T) {
@@ -85,11 +84,7 @@ func replicationTestSuite() {
 				if err != nil {
 					return err
 				}
-				cond := meta.FindStatusCondition(mb.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)
-				if cond == nil {
-					return errors.New("couldn't find condition SyncedToRemote")
-				}
-				if cond.Status != metav1.ConditionTrue {
+				if !meta.IsStatusConditionTrue(mb.Status.Conditions, mantlev1.BackupConditionSyncedToRemote) {
 					return errors.New("status of SyncedToRemote condition is not True")
 				}
 				return nil

--- a/test/e2e/singlek8s/restore_test.go
+++ b/test/e2e/singlek8s/restore_test.go
@@ -197,8 +197,7 @@ func (test *restoreTest) testRestore() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking if the status is updated")
-		readyToUseCondition := meta.FindStatusCondition(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)
-		Expect(readyToUseCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)).To(BeTrue())
 	})
 
 	It("should not update clone image if it is already created", func() {
@@ -487,8 +486,7 @@ func (test *restoreTest) testCloneImageFromBackup() {
 				return err
 			}
 
-			condition := meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)
-			if condition == nil || condition.Status != metav1.ConditionTrue {
+			if !meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
 				return fmt.Errorf("backup is not ready")
 			}
 			return nil

--- a/test/e2e/singlek8s/util.go
+++ b/test/e2e/singlek8s/util.go
@@ -17,7 +17,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -412,8 +411,7 @@ func isMantleBackupReady(namespace, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	cond := meta.FindStatusCondition(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse).Status
-	return cond == metav1.ConditionTrue, nil
+	return meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse), nil
 }
 
 func isMantleRestoreReady(namespace, name string) bool {
@@ -431,8 +429,7 @@ func isMantleRestoreReady(namespace, name string) bool {
 	if restore.Status.Conditions == nil {
 		return false
 	}
-	readyToUseCondition := meta.FindStatusCondition(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)
-	return readyToUseCondition.Status == metav1.ConditionTrue
+	return meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)
 }
 
 func writeTestData(namespace, pvc string, data []byte) error {


### PR DESCRIPTION
FindStatusCondition returns nil if the condition is not found, so we should check for nil. However, in some cases, we didn't do this. When checking if the condition is true, the function IsStatusConditionTrue is more suitable, so use that instead.