### PR TITLE
remove namespace from MantleBackupSpec

### DIFF
--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -16,9 +16,6 @@ type MantleBackupSpec struct {
 	// +kubebuilder:validation:Required
 	PVC string `json:"pvc,omitempty"`
 
-	// 'namespace' specifies backup target Namespace
-	Namespace string `json:"namespace,omitempty"`
-
 	// NOTE: we CANNOT use metav1.Duration for Expire due to an unresolved k8s bug.
 	// See https://github.com/kubernetes/apiextensions-apiserver/issues/56 for the details.
 

--- a/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
+++ b/charts/mantle-cluster-wide/templates/mantle.cybozu.io_mantlebackups.yaml
@@ -53,9 +53,6 @@ spec:
                   rule: self <= duration('360h')
                 - message: spec.expire is immutable
                   rule: self == oldSelf
-              namespace:
-                description: '''namespace'' specifies backup target Namespace'
-                type: string
               pvc:
                 description: '''pvc'' specifies backup target PVC'
                 type: string

--- a/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
+++ b/config/crd/bases/mantle.cybozu.io_mantlebackups.yaml
@@ -53,9 +53,6 @@ spec:
                   rule: self <= duration('360h')
                 - message: spec.expire is immutable
                   rule: self == oldSelf
-              namespace:
-                description: '''namespace'' specifies backup target Namespace'
-                type: string
               pvc:
                 description: '''pvc'' specifies backup target PVC'
                 type: string


### PR DESCRIPTION
We've found `.spec.namespace` of MantleBackup is not useful anymore, so let's remove it.