### PR TITLE
remove unnecessary TTY: true

### DIFF
--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -177,7 +177,6 @@ spec:
             runAsGroup: 2016
             runAsNonRoot: true
             runAsUser: 2016
-          tty: true
           volumeMounts:
           - mountPath: /etc/ceph
             name: ceph-config

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -168,7 +168,6 @@ spec:
           runAsGroup: 2016
           runAsNonRoot: true
           runAsUser: 2016
-        tty: true
         volumeMounts:
         - mountPath: /etc/ceph
           name: ceph-config

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -1150,7 +1150,6 @@ func (r *MantleBackupReconciler) createOrUpdateExportJob(ctx context.Context, ta
 				},
 				Image:           r.podImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				TTY:             true,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						MountPath: "/etc/ceph",
@@ -1687,7 +1686,6 @@ func (r *MantleBackupReconciler) createImportJob(
 			},
 			Image:           r.podImage,
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			TTY:             true,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/etc/ceph",


### PR DESCRIPTION
This PR removes all `tty: true` in the resources. I'm not too sure if this change is completely harmless, i.e., there's no functional change. However, [the Kubernetes documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#container-v1-core) explains this field as follows:

> tty
> boolean
> Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.

And all occurrences of `tty: true` in the Mantle's code don't have `stdin: true` alongside with them, so presumably, they aren't currently doing anything meaningful.