### PR TITLE
ci: don't purge deb packages in e2e-multiple-k8s-clusters

### DIFF
--- a/.github/workflows/e2e-multiple-k8s-clusters.yaml
+++ b/.github/workflows/e2e-multiple-k8s-clusters.yaml
@@ -27,7 +27,6 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: sudo apt-get update
-      - uses: ./.github/actions/purge-unnecessary-deb-packages
       - uses: ./.github/actions/set-up-kvm-for-e2e-tests
       - name: cache go dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
We're using a larger runner for e2e-multiple-k8s-clusters, and its
storage should have a large free space, so we don't have to consume time
to purge deb packages.