### PR TITLE
Fix discard job

### DIFF
--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -1689,6 +1689,7 @@ blkdiscard /dev/discard-rbd
 						DevicePath: "/dev/discard-rbd",
 					},
 				},
+				ImagePullPolicy: corev1.PullIfNotPresent,
 			},
 		}
 

--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -349,9 +349,11 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPV() {
 		err = k8sClient.Update(ctx, &pv)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = k8sClient.Get(ctx, client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
-		Expect(err).To(HaveOccurred())
-		Expect(errors.IsNotFound(err)).To(BeTrue())
+		Eventually(ctx, func(g Gomega) {
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
+		}).Should(Succeed())
 	})
 
 	It("should skip deleting the PV if it does not exist", func(ctx SpecContext) {

--- a/test/e2e/multik8s/suite_test.go
+++ b/test/e2e/multik8s/suite_test.go
@@ -89,7 +89,7 @@ func replicationTestSuite() {
 					return errors.New("status of SyncedToRemote condition is not True")
 				}
 				return nil
-			}, "5m", "1s").Should(Succeed())
+			}, "10m", "1s").Should(Succeed())
 
 			By("checking PVC is replicated")
 			Eventually(func() error {


### PR DESCRIPTION
This PR contains the following commits:

- check sync-mode annot is set before starting to reconcile MB in secondary
    - This commit ensures that sync-mode annotation is correctly set before discard and import Jobs are created. Currently, mantle-controller does NOT wait for a discard Job to finish before an import Job is created, because an empty sync-mode passes [this if condition](https://github.com/cybozu-go/mantle/blob/fc095a2c6c9944faf2889aad703ee39e41ccc872/internal/controller/mantlebackup_controller.go#L1532-L1534). This behaviour isn't what we expect. This commit fixes this problem.
- set ImagePullPolicy: PullIfNotPresent to discard Job
    - This commit sets `ImagePullPolicy` to discard Jobs. Without this setting, this field is set to `Always`, and it breaks our e2e tests, because there's no [`controller:latest` image](https://github.com/cybozu-go/mantle/blob/main/charts/mantle/values.yaml#L3-L6) on the Internet.
- check restoring PV finalizer before checking cluster ID in PersisntetVolumeReconciler
    - (This is a _kaizen_.) `getCephClusterIDFromSCName` works correctly only for storage class names provisioned by Rook/Ceph. However, the PVs requested to PersistentVolumeReconciler aren't necessarily provisioned by Rook/Ceph. This commit fixes this problem by checking that the PV has the correct finalizer before calling `getCephClusterIDFromSCName`.
- use Patch to update .Status.CreatedAt in CreateOrUpdateMantleBackup rpc
    - (This is a _kaizen_.) In `CreateOrUpdateMantleBackup` rpc, we first need to create (or update) a MantleBackup and then update its status. This "update-after-create" process is likely to fail due to "the object has been modified" error, unless the cache for kubeapi refreshes quickly after the creation. This commit fixes this problem by using Patch instead of Update for the status.
- test/e2e: lenghthen timeout to wait for SyncToRemote to be True
    - (This is a _kaizen_.) According to some tries, the current timeout 5m is too short to wait for SyncToRemote to be true in the e2e test, probably due to the exponential backoff of `Requeue: true`. This commit lengthens its value to 10m to resolve this problem in an ad hoc way. A fundamental resolution should come in another PR.
- test: use Eventually to check if PV is deleted in testDeleteRestoringPV
    - This is a _kaizen_.