### PR TITLE
support http(s) proxy

### DIFF
--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -88,6 +88,15 @@ spec:
             {{- with .Values.controller.gcInterval }}
             - --gc-interval={{ . }}
             {{- end }}
+            {{- with .Values.controller.httpProxy }}
+            - --http-proxy={{ . }}
+            {{- end }}
+            {{- with .Values.controller.httpsProxy }}
+            - --https-proxy={{ . }}
+            {{- end }}
+            {{- with .Values.controller.noProxy }}
+            - --no-proxy={{ . }}
+            {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -72,6 +72,12 @@ type ObjectStorageSettings struct {
 	Endpoint        string
 }
 
+type ProxySettings struct {
+	HttpProxy  string
+	HttpsProxy string
+	NoProxy    string
+}
+
 // MantleBackupReconciler reconciles a MantleBackup object
 type MantleBackupReconciler struct {
 	client.Client
@@ -85,6 +91,7 @@ type MantleBackupReconciler struct {
 	envSecret             string
 	objectStorageSettings *ObjectStorageSettings // This should be non-nil if and only if role equals 'primary' or 'secondary'.
 	objectStorageClient   objectstorage.Bucket
+	proxySettings         *ProxySettings
 }
 
 // NewMantleBackupReconciler returns NodeReconciler.
@@ -97,6 +104,7 @@ func NewMantleBackupReconciler(
 	podImage string,
 	envSecret string,
 	objectStorageSettings *ObjectStorageSettings,
+	proxySettings *ProxySettings,
 ) *MantleBackupReconciler {
 	return &MantleBackupReconciler{
 		Client:                client,
@@ -109,6 +117,7 @@ func NewMantleBackupReconciler(
 		podImage:              podImage,
 		envSecret:             envSecret,
 		objectStorageSettings: objectStorageSettings,
+		proxySettings:         proxySettings,
 	}
 }
 
@@ -1324,6 +1333,18 @@ func (r *MantleBackupReconciler) createOrUpdateExportDataUploadJob(ctx context.C
 								Key: "AWS_SECRET_ACCESS_KEY",
 							},
 						},
+					},
+					{
+						Name:  "HTTP_PROXY",
+						Value: r.proxySettings.HttpProxy,
+					},
+					{
+						Name:  "HTTPS_PROXY",
+						Value: r.proxySettings.HttpsProxy,
+					},
+					{
+						Name:  "NO_PROXY",
+						Value: r.proxySettings.NoProxy,
 					},
 				},
 				Image:           r.podImage,

--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -58,6 +58,7 @@ func (test *mantleRestoreControllerUnitTest) setupEnv() {
 			"dummy image",
 			"",
 			nil,
+			nil,
 		)
 		backupReconciler.ceph = testutil.NewFakeRBD()
 		err := backupReconciler.SetupWithManager(test.mgrUtil.GetManager())

--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -370,6 +370,12 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPV() {
 		err := test.reconciler.createOrUpdateRestoringPV(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Make sure the client cache stores the restoring PV.
+		Eventually(func(g Gomega) {
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).Should(Succeed())
+
 		err = test.reconciler.deleteRestoringPV(ctx, restoreDifferent)
 		Expect(err).To(HaveOccurred())
 

--- a/test/e2e/testdata/values-mantle-primary-template.yaml
+++ b/test/e2e/testdata/values-mantle-primary-template.yaml
@@ -6,3 +6,6 @@ controller:
   envSecret: export-data
   exportDataStorageClass: rook-ceph-block
   gcInterval: 1s
+  #httpProxy: http://host.minikube.internal:8899
+  #httpsProxy: http://host.minikube.internal:8899
+  #noProxy: localhost,127.0.0.1,10.96.0.0/12


### PR DESCRIPTION
This PR introduces `-http-proxy`, `-https-proxy`, and `-no-proxy` command-line arguments to support http(s) proxies that should be used to access object storages and gRPC services from the primary Mantle controller.