### PR TITLE
enable errorlint of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,10 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - copyloopvar
+    - errorlint
     - goconst
     - gocyclo
     - gofmt

--- a/internal/ceph/rbd.go
+++ b/internal/ceph/rbd.go
@@ -15,7 +15,7 @@ func (c *cephCmdImpl) RBDClone(pool, srcImage, srcSnap, dstImage, features strin
 		src, dst,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to clone RBD image: %v", err)
+		return fmt.Errorf("failed to clone RBD image: %w", err)
 	}
 
 	return nil
@@ -25,13 +25,13 @@ func (c *cephCmdImpl) RBDClone(pool, srcImage, srcSnap, dstImage, features strin
 func (c *cephCmdImpl) RBDInfo(pool, image string) (*RBDImageInfo, error) {
 	out, err := c.command.execute("rbd", "info", "--format", "json", fmt.Sprintf("%s/%s", pool, image))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get RBD info: %v", err)
+		return nil, fmt.Errorf("failed to get RBD info: %w", err)
 	}
 
 	imageInfo := &RBDImageInfo{}
 	err = json.Unmarshal(out, imageInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal RBD info: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal RBD info: %w", err)
 	}
 	return imageInfo, nil
 }
@@ -40,13 +40,13 @@ func (c *cephCmdImpl) RBDInfo(pool, image string) (*RBDImageInfo, error) {
 func (c *cephCmdImpl) RBDLs(pool string) ([]string, error) {
 	out, err := c.command.execute("rbd", "ls", "-p", pool, "--format", "json")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list RBD images: %v", err)
+		return nil, fmt.Errorf("failed to list RBD images: %w", err)
 	}
 
 	var images []string
 	err = json.Unmarshal(out, &images)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal RBD images: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal RBD images: %w", err)
 	}
 
 	return images, nil
@@ -56,7 +56,7 @@ func (c *cephCmdImpl) RBDLs(pool string) ([]string, error) {
 func (c *cephCmdImpl) RBDRm(pool, image string) error {
 	_, err := c.command.execute("rbd", "rm", fmt.Sprintf("%s/%s", pool, image))
 	if err != nil {
-		return fmt.Errorf("failed to remove RBD image: %v", err)
+		return fmt.Errorf("failed to remove RBD image: %w", err)
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func (c *cephCmdImpl) CephRBDTaskAddTrashRemove(pool, imageID string) error {
 func (c *cephCmdImpl) RBDSnapCreate(pool, image, snap string) error {
 	_, err := c.command.execute("rbd", "snap", "create", fmt.Sprintf("%s/%s@%s", pool, image, snap))
 	if err != nil {
-		return fmt.Errorf("failed to create RBD snapshot: %v", err)
+		return fmt.Errorf("failed to create RBD snapshot: %w", err)
 	}
 
 	return nil
@@ -94,13 +94,13 @@ func (c *cephCmdImpl) RBDSnapCreate(pool, image, snap string) error {
 func (c *cephCmdImpl) RBDSnapLs(pool, image string) ([]RBDSnapshot, error) {
 	out, err := c.command.execute("rbd", "snap", "ls", "--format", "json", fmt.Sprintf("%s/%s", pool, image))
 	if err != nil {
-		return nil, fmt.Errorf("failed to list RBD snapshots: %v", err)
+		return nil, fmt.Errorf("failed to list RBD snapshots: %w", err)
 	}
 
 	var snapshots []RBDSnapshot
 	err = json.Unmarshal(out, &snapshots)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal RBD snapshots: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal RBD snapshots: %w", err)
 	}
 
 	return snapshots, nil
@@ -110,7 +110,7 @@ func (c *cephCmdImpl) RBDSnapLs(pool, image string) ([]RBDSnapshot, error) {
 func (c *cephCmdImpl) RBDSnapRm(pool, image, snap string) error {
 	_, err := c.command.execute("rbd", "snap", "rm", fmt.Sprintf("%s/%s@%s", pool, image, snap))
 	if err != nil {
-		return fmt.Errorf("failed to remove RBD snapshot: %v", err)
+		return fmt.Errorf("failed to remove RBD snapshot: %w", err)
 	}
 
 	return nil

--- a/internal/controller/mantlerestore_controller.go
+++ b/internal/controller/mantlerestore_controller.go
@@ -205,7 +205,7 @@ func (r *MantleRestoreReconciler) cloneImageFromBackup(ctx context.Context, rest
 	pv := corev1.PersistentVolume{}
 	err := json.Unmarshal([]byte(backup.Status.PVManifest), &pv)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal PV manifest: %v", err)
+		return fmt.Errorf("failed to unmarshal PV manifest: %w", err)
 	}
 
 	bkImage := pv.Spec.CSI.VolumeAttributes["imageName"]
@@ -215,14 +215,14 @@ func (r *MantleRestoreReconciler) cloneImageFromBackup(ctx context.Context, rest
 
 	images, err := r.ceph.RBDLs(restore.Status.Pool)
 	if err != nil {
-		return fmt.Errorf("failed to list RBD images: %v", err)
+		return fmt.Errorf("failed to list RBD images: %w", err)
 	}
 
 	// check if the image already exists
 	if slices.Contains(images, r.restoringRBDImageName(restore)) {
 		info, err := r.ceph.RBDInfo(restore.Status.Pool, r.restoringRBDImageName(restore))
 		if err != nil {
-			return fmt.Errorf("failed to get RBD info: %v", err)
+			return fmt.Errorf("failed to get RBD info: %w", err)
 		}
 		if info.Parent == nil {
 			return fmt.Errorf("failed to get RBD info: parent field is empty")
@@ -378,7 +378,7 @@ func (r *MantleRestoreReconciler) deleteRestoringPVC(ctx context.Context, restor
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get PVC: %v", err)
+		return fmt.Errorf("failed to get PVC: %w", err)
 	}
 
 	if pvc.Annotations[PVCAnnotationRestoredBy] != string(restore.UID) {
@@ -386,7 +386,7 @@ func (r *MantleRestoreReconciler) deleteRestoringPVC(ctx context.Context, restor
 	}
 
 	if err := r.client.Delete(ctx, &pvc); err != nil {
-		return fmt.Errorf("failed to delete PVC: %v", err)
+		return fmt.Errorf("failed to delete PVC: %w", err)
 	}
 
 	return nil
@@ -402,7 +402,7 @@ func (r *MantleRestoreReconciler) deleteRestoringPV(ctx context.Context, restore
 			// removed by GarbageCollectorRunner.
 			return nil
 		}
-		return fmt.Errorf("failed to get PV: %v", err)
+		return fmt.Errorf("failed to get PV: %w", err)
 	}
 
 	if pv.Annotations[PVAnnotationRestoredBy] != string(restore.UID) {
@@ -410,7 +410,7 @@ func (r *MantleRestoreReconciler) deleteRestoringPV(ctx context.Context, restore
 	}
 
 	if err := r.client.Delete(ctx, &pv); err != nil {
-		return fmt.Errorf("failed to delete PV: %v", err)
+		return fmt.Errorf("failed to delete PV: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
_This is a kaizen._ We should use `%w` instead of `%v` when wrapping an error by `fmt.Errorf`. This PR fixes this problem by enabling errorlint of golangci-lint and fixing the code it pointed.