### PR TITLE
charts/mantle: change `image:` so that mantle can work right out of the box

### DIFF
--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -37,7 +37,9 @@ spec:
               drop:
               - "ALL"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/mantle/values.yaml
+++ b/charts/mantle/values.yaml
@@ -1,9 +1,9 @@
 replicaCount: 1
 
 image:
-  repository: controller
-  pullPolicy: IfNotPresent
-  tag: latest
+  repository: ghcr.io/cybozu-go/mantle
+  pullPolicy:
+  tag: # {{ .Chart.AppVersion }}
 
 imagePullSecrets: []
 nameOverride: ""

--- a/test/e2e/testdata/values-mantle-primary-template.yaml
+++ b/test/e2e/testdata/values-mantle-primary-template.yaml
@@ -1,3 +1,8 @@
+image:
+  repository: controller
+  pullPolicy: IfNotPresent
+  tag: latest
+
 controller:
   role: primary
   mantleServiceEndpoint: {ENDPOINT}

--- a/test/e2e/testdata/values-mantle-secondary-template.yaml
+++ b/test/e2e/testdata/values-mantle-secondary-template.yaml
@@ -1,3 +1,8 @@
+image:
+  repository: controller
+  pullPolicy: IfNotPresent
+  tag: latest
+
 controller:
   role: secondary
   mantleServiceEndpoint: ":58080"

--- a/test/e2e/testdata/values-mantle1.yaml
+++ b/test/e2e/testdata/values-mantle1.yaml
@@ -1,3 +1,8 @@
+image:
+  repository: controller
+  pullPolicy: IfNotPresent
+  tag: latest
+
 controller:
   overwriteMBCSchedule: "* * * * *"
   gcInterval: 1s

--- a/test/e2e/testdata/values-mantle2.yaml
+++ b/test/e2e/testdata/values-mantle2.yaml
@@ -1,2 +1,7 @@
+image:
+  repository: controller
+  pullPolicy: IfNotPresent
+  tag: latest
+
 controller:
   gcInterval: 1s


### PR DESCRIPTION
_This is a kaizen._

The current values of `image:` in values.yaml of charts/mantle are written for the e2e tests. Thus, the users need to overwrite them when they want to use Mantle in the real environments.

This commit fixes the problem above by changing the values for real deployment.