### PR TITLE
fix export-diff command's offset check

### DIFF
--- a/ceph/export-diff.patch
+++ b/ceph/export-diff.patch
@@ -11,7 +11,7 @@
  // encryption arguments
  static const std::string ENCRYPTION_FORMAT("encryption-format");
 diff --git a/src/tools/rbd/action/Export.cc b/src/tools/rbd/action/Export.cc
-index ddcf0f2c30c..01c96d40911 100644
+index ddcf0f2c30c..2ba0be2ebb1 100644
 --- a/src/tools/rbd/action/Export.cc
 +++ b/src/tools/rbd/action/Export.cc
 @@ -123,16 +123,27 @@ private:
@@ -106,7 +106,7 @@ index ddcf0f2c30c..01c96d40911 100644
  
    if (fd != 1)
      close(fd);
-@@ -260,10 +274,52 @@ void get_arguments_diff(po::options_description *positional,
+@@ -260,10 +274,51 @@ void get_arguments_diff(po::options_description *positional,
    options->add_options()
      (at::FROM_SNAPSHOT_NAME.c_str(), po::value<std::string>(),
       "snapshot starting point")
@@ -132,8 +132,7 @@ index ddcf0f2c30c..01c96d40911 100644
 +  if (r < 0)
 +    return r;
 +  
-+  // ⚠️ should be test when offset == info.size
-+  if (*offset > info.size) {
++  if (*offset >= info.size) {
 +    std::cerr << "rbd: offset " << *offset << " exceeds image size "
 +              << info.size << std::endl;
 +    return -EINVAL;
@@ -160,7 +159,7 @@ index ddcf0f2c30c..01c96d40911 100644
  int execute_diff(const po::variables_map &vm,
                   const std::vector<std::string> &ceph_global_init_args) {
    size_t arg_index = 0;
-@@ -290,6 +346,26 @@ int execute_diff(const po::variables_map &vm,
+@@ -290,6 +345,26 @@ int execute_diff(const po::variables_map &vm,
      from_snap_name = vm[at::FROM_SNAPSHOT_NAME].as<std::string>();
    }
  
@@ -187,7 +186,7 @@ index ddcf0f2c30c..01c96d40911 100644
    librados::Rados rados;
    librados::IoCtx io_ctx;
    librbd::Image image;
-@@ -299,9 +375,28 @@ int execute_diff(const po::variables_map &vm,
+@@ -299,9 +374,28 @@ int execute_diff(const po::variables_map &vm,
      return r;
    }
  
@@ -216,7 +215,7 @@ index ddcf0f2c30c..01c96d40911 100644
                       vm[at::WHOLE_OBJECT].as<bool>(), path.c_str(),
                       vm[at::NO_PROGRESS].as<bool>());
    if (r < 0) {
-@@ -501,7 +596,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
+@@ -501,7 +595,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
    const char *last_snap = NULL;
    for (size_t i = 0; i < snaps.size(); ++i) {
      utils::snap_set(image, snaps[i].name.c_str());
@@ -226,7 +225,7 @@ index ddcf0f2c30c..01c96d40911 100644
      if (r < 0) {
        return r;
      }
-@@ -509,7 +605,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
+@@ -509,7 +604,8 @@ static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd
      last_snap = snaps[i].name.c_str();
    }
    utils::snap_set(image, std::string(""));


### PR DESCRIPTION
patch is generated from branch below.
https://github.com/cybozu/ceph/commits/rbd-export-v18.2.4/