### PR TITLE
Remove unnecessary namespece setting

### DIFF
--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -2201,7 +2201,6 @@ func (r *MantleBackupReconciler) secondaryCleanup(
 
 	var discardPV corev1.PersistentVolume
 	discardPV.SetName(MakeDiscardPVName(target))
-	discardPV.SetNamespace(r.managedCephClusterID)
 	if err := r.Client.Delete(ctx, &discardPV); err != nil && !aerrors.IsNotFound(err) {
 		return ctrl.Result{}, fmt.Errorf("failed to delete discard PV: %w", err)
 	}

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -1704,7 +1704,6 @@ var _ = Describe("import", func() {
 			// Create discard data PV
 			var discardDataPV corev1.PersistentVolume
 			discardDataPV.SetName(MakeDiscardPVName(backup))
-			discardDataPV.SetNamespace(nsController)
 			discardDataPV.Spec.HostPath = &corev1.HostPathVolumeSource{Path: "/dummy"}
 			discardDataPV.Spec.StorageClassName = "manual"
 			discardDataPV.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
@@ -1754,7 +1753,7 @@ var _ = Describe("import", func() {
 			Expect(discardDataPVC.GetDeletionTimestamp().IsZero()).To(BeFalse())
 
 			// Check that PV has deletionTimestamp
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup), Namespace: nsController}, &discardDataPV)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup)}, &discardDataPV)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(discardDataPV.GetDeletionTimestamp().IsZero()).To(BeFalse())
 		})
@@ -1798,7 +1797,7 @@ var _ = Describe("import", func() {
 			Expect(result.Requeue).To(BeFalse())
 
 			var pv corev1.PersistentVolume
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup), Namespace: nsController}, &pv)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup)}, &pv)
 			Expect(err).To(HaveOccurred())
 			Expect(aerrors.IsNotFound(err)).To(BeTrue())
 
@@ -1879,7 +1878,7 @@ var _ = Describe("import", func() {
 			Expect(result.Requeue).To(BeTrue())
 
 			var pv corev1.PersistentVolume
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup), Namespace: nsController}, &pv)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup)}, &pv)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pv.GetLabels()["app.kubernetes.io/name"]).To(Equal(labelAppNameValue))
 			Expect(pv.GetLabels()["app.kubernetes.io/component"]).To(Equal(labelComponentDiscardVolume))

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -783,7 +783,7 @@ func WaitTemporaryPVCsDeleted(ctx SpecContext, primaryMB, secondaryMB *mantlev1.
 	WaitTemporarySecondaryPVCsDeleted(ctx, secondaryMB)
 }
 
-func WaitPVDeleted(ctx SpecContext, cluster int, namespace, pvName string) {
+func WaitPVDeleted(ctx SpecContext, cluster int, pvName string) {
 	GinkgoHelper()
 	By("waiting for a PV to be deleted")
 	Eventually(ctx, func(g Gomega) {
@@ -798,7 +798,7 @@ func WaitPVDeleted(ctx SpecContext, cluster int, namespace, pvName string) {
 
 func WaitTemporarySecondaryPVsDeleted(ctx SpecContext, secondaryMB *mantlev1.MantleBackup) {
 	GinkgoHelper()
-	WaitPVDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace, controller.MakeDiscardPVName(secondaryMB))
+	WaitPVDeleted(ctx, SecondaryK8sCluster, controller.MakeDiscardPVName(secondaryMB))
 }
 
 func WaitTemporaryS3ObjectDeleted(ctx SpecContext, primaryMB *mantlev1.MantleBackup) {


### PR DESCRIPTION
We can remove namespace fields of PVs because PV is cluster resource.