### PR TITLE
cleanup: remove unnecessary namespaces of pvs

### DIFF
--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -2564,7 +2564,6 @@ func (r *MantleBackupReconciler) secondaryCleanup(
 
 	var discardPV corev1.PersistentVolume
 	discardPV.SetName(MakeDiscardPVName(target))
-	discardPV.SetNamespace(r.managedCephClusterID)
 	if err := r.Client.Delete(ctx, &discardPV); err != nil && !aerrors.IsNotFound(err) {
 		return ctrl.Result{}, fmt.Errorf("failed to delete discard PV: %w", err)
 	}

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -1947,7 +1947,6 @@ var _ = Describe("import", func() {
 			GinkgoHelper()
 			var discardDataPV corev1.PersistentVolume
 			discardDataPV.SetName(MakeDiscardPVName(backup))
-			discardDataPV.SetNamespace(nsController)
 			discardDataPV.Spec.HostPath = &corev1.HostPathVolumeSource{Path: "/dummy"}
 			discardDataPV.Spec.StorageClassName = "manual"
 			discardDataPV.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
@@ -1972,7 +1971,7 @@ var _ = Describe("import", func() {
 			var pv corev1.PersistentVolume
 			err := k8sClient.Get(
 				ctx,
-				types.NamespacedName{Name: MakeDiscardPVName(backup), Namespace: nsController},
+				types.NamespacedName{Name: MakeDiscardPVName(backup)},
 				&pv,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2101,7 +2100,7 @@ var _ = Describe("import", func() {
 			var pv corev1.PersistentVolume
 			err = k8sClient.Get(
 				ctx,
-				types.NamespacedName{Name: MakeDiscardPVName(backup2), Namespace: nsController},
+				types.NamespacedName{Name: MakeDiscardPVName(backup2)},
 				&pv,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -2134,7 +2133,7 @@ var _ = Describe("import", func() {
 			Expect(result.Requeue).To(BeFalse())
 
 			var pv corev1.PersistentVolume
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup), Namespace: nsController}, &pv)
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: MakeDiscardPVName(backup)}, &pv)
 			Expect(err).To(HaveOccurred())
 			Expect(aerrors.IsNotFound(err)).To(BeTrue())
 

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -828,7 +828,7 @@ func WaitTemporaryPVCsDeleted(ctx SpecContext, primaryMB, secondaryMB *mantlev1.
 	WaitTemporarySecondaryPVCsDeleted(ctx, secondaryMB)
 }
 
-func WaitPVDeleted(ctx SpecContext, cluster int, namespace, pvName string) {
+func WaitPVDeleted(ctx SpecContext, cluster int, pvName string) {
 	GinkgoHelper()
 	By("waiting for a PV to be deleted")
 	Eventually(ctx, func(g Gomega) {
@@ -843,7 +843,7 @@ func WaitPVDeleted(ctx SpecContext, cluster int, namespace, pvName string) {
 
 func WaitTemporarySecondaryPVsDeleted(ctx SpecContext, secondaryMB *mantlev1.MantleBackup) {
 	GinkgoHelper()
-	WaitPVDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace, controller.MakeDiscardPVName(secondaryMB))
+	WaitPVDeleted(ctx, SecondaryK8sCluster, controller.MakeDiscardPVName(secondaryMB))
 }
 
 func WaitTemporaryS3ObjectsDeleted(ctx SpecContext, primaryMB *mantlev1.MantleBackup) {


### PR DESCRIPTION
We can remove namespaces of pvs because pv is cluster resource.