### PR TITLE
Support mTLS

### DIFF
--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -102,6 +102,24 @@ spec:
             {{- with .Values.controller.backupTransferPartSize }}
             - --backup-transfer-part-size={{ . }}
             {{- end }}
+            {{- with .Values.controller.grpcTLSClientCertPath }}
+            - --grpc-tls-client-cert-path={{ . }}
+            {{- end }}
+            {{- with .Values.controller.grpcTLSClientKeyPath }}
+            - --grpc-tls-client-key-path={{ . }}
+            {{- end }}
+            {{- with .Values.controller.grpcTLSClientCAPath }}
+            - --grpc-tls-client-ca-path={{ . }}
+            {{- end }}
+            {{- with .Values.controller.grpcTLSServerCertPath }}
+            - --grpc-tls-server-cert-path={{ . }}
+            {{- end }}
+            {{- with .Values.controller.grpcTLSServerKeyPath }}
+            - --grpc-tls-server-key-path={{ . }}
+            {{- end }}
+            {{- with .Values.controller.grpcTLSServerCAPath }}
+            - --grpc-tls-server-ca-path={{ . }}
+            {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-config
+            {{- with .Values.controller.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - /manager
           args:
@@ -240,6 +243,9 @@ spec:
           name: mon-endpoint-volume
         - emptyDir: {}
           name: ceph-config
+        {{- with .Values.controller.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -62,7 +62,19 @@ test-multiple-k8s-clusters:
 	$(MAKE) install-rook-ceph-operator
 	$(MAKE) install-rook-ceph-cluster1
 	$(MAKE) install-ceph-object-store
+	$(MAKE) install-cert-manager
 	$(MAKE) install-mantle-cluster-wide
+# set up a k8s cluster for primary mantle
+	$(MAKE) launch-minikube MINIKUBE_PROFILE=$(MINIKUBE_PROFILE_PRIMARY)
+	$(MAKE) install-rook-ceph-operator
+	$(MAKE) install-rook-ceph-cluster1
+	$(MAKE) install-ceph-object-store-secret
+	$(MAKE) install-cert-manager
+	$(MAKE) install-mantle-cluster-wide
+# prepare TLS certificates
+	$(MAKE) install-tls-certificates NAMESPACE=$(CEPH_CLUSTER1_NAMESPACE)
+# start mantle-controller in the secondary cluster
+	$(MAKE) minikube-profile-secondary
 	sed \
 		-e "s%{OBJECT_STORAGE_BUCKET_NAME}%$$(cat $(TMPDIR)/cm-export-data.json | jq -r .data.BUCKET_NAME)%" \
 		-e "s%{OBJECT_STORAGE_ENDPOINT}%http://$$(cat $(TMPDIR)/cm-export-data.json | jq -r .data.BUCKET_HOST)%" \
@@ -72,12 +84,11 @@ test-multiple-k8s-clusters:
 		NAMESPACE=$(CEPH_CLUSTER1_NAMESPACE) \
 		HELM_RELEASE=mantle \
 		VALUES_YAML=testdata/values-mantle-secondary.yaml
-# set up a k8s cluster for primary mantle
-	$(MAKE) launch-minikube MINIKUBE_PROFILE=$(MINIKUBE_PROFILE_PRIMARY)
-	$(MAKE) install-rook-ceph-operator
-	$(MAKE) install-rook-ceph-cluster1
-	$(MAKE) install-ceph-object-store-secret
-	$(MAKE) install-mantle-cluster-wide
+# update the TLS certificates to include IP SAN of the secondary mantle-controller endpoint
+	$(MAKE) install-tls-certificates NAMESPACE=$(CEPH_CLUSTER1_NAMESPACE)
+	$(MINIKUBE) -p $(MINIKUBE_PROFILE_SECONDARY) kubectl -- rollout restart -n $(CEPH_CLUSTER1_NAMESPACE) deploy/mantle-controller
+# start mantle-controller in the primary cluster
+	$(MAKE) minikube-profile-primary
 	sed \
 		-e "s%{ENDPOINT}%$$($(MINIKUBE) service list -p $(MINIKUBE_PROFILE_SECONDARY) -o json | jq -r '.[] | select(.Name == "mantle" and .Namespace == "rook-ceph") | .URLs | select(. | length > 0)[]' | head -1 | sed -r 's/^http:\/\///')%" \
 		-e "s%{OBJECT_STORAGE_BUCKET_NAME}%$$(cat $(TMPDIR)/cm-export-data.json | jq -r .data.BUCKET_NAME)%" \
@@ -90,7 +101,6 @@ test-multiple-k8s-clusters:
 		HELM_RELEASE=mantle \
 		VALUES_YAML=testdata/values-mantle-primary.yaml
 # start testing
-	$(MINIKUBE) profile $(MINIKUBE_PROFILE_PRIMARY)
 	$(MAKE) do-test-multik8s
 
 .PHONY: clean
@@ -220,6 +230,51 @@ install-ceph-object-store:
 .PHONY: install-ceph-object-store-secret
 install-ceph-object-store-secret:
 	$(KUBECTL) apply -f $(TMPDIR)/secret-export-data.json
+
+.PHONY: install-cert-manager
+install-cert-manager:
+	$(HELM) upgrade --install --version $(CERT_MANAGER_VERSION) --repo https://charts.jetstack.io \
+		--create-namespace --namespace cert-manager --set crds.enabled=true --wait \
+		cert-manager cert-manager
+
+.PHONY: install-tls-certificates
+install-tls-certificates:
+# Create a TLS certificate in the primary cluster.
+	$(MAKE) minikube-profile-primary
+	$(KUBECTL) apply -f testdata/cert-primary.yaml
+# In order to get the regenerated Secret for sure, delete the existing secret if any.
+	kubectl delete secret -n $(NAMESPACE) cert-mantle || true
+# Wait until a Secret for the certificates is created.
+	until kubectl get secret -n $(NAMESPACE) cert-mantle >/dev/null ; do sleep 1; done
+# Dump ca.crt in the secret to import it to the secondary cluster.
+	kubectl get secret -n $(NAMESPACE) cert-mantle -o json | jq -r '.data."ca.crt"' | base64 -d > $(TMPDIR)/primary-ca.crt
+	$(MAKE) minikube-profile-secondary
+	kubectl create cm mantle-primary-ca-crt -n $(NAMESPACE) --from-file=ca.crt=$(TMPDIR)/primary-ca.crt \
+		--output yaml --dry-run=client | kubectl apply -f -
+# Create a TLS certificate in the secondary cluster.
+#
+# Before creating a Certificate resource, we need to replace the {ENDPOINT} placeholder
+# in the template file with the IP address of the secondary mantle-controller's Service endpoint.
+# By doing so, the generated TLS certificate will have an IP SAN of that IP address,
+# so the primary mantle-controller can access the secondary via TLS without any hostname.
+# If the Service doesn't exist (i.e., the secondary mantle-controller is not started yet),
+# just erase the placeholder.
+	sed \
+		-e "s%{ENDPOINT}%$$(\
+			IPADDR=$$($(MINIKUBE) service list -p $(MINIKUBE_PROFILE_SECONDARY) -o json | jq -r '.[] | select(.Name == "mantle" and .Namespace == "rook-ceph") | .URLs | select(. | length > 0)[]' | head -1 | sed -r 's/^http:\/\/([^:]+).*$$/\1/'); \
+			if [ "$$IPADDR" = "" ]; then echo -n ""; else echo -n "\"$${IPADDR}\""; fi)%" \
+		testdata/cert-secondary-template.yaml \
+		> $(TMPDIR)/cert-secondary.yaml
+	$(KUBECTL) apply -f $(TMPDIR)/cert-secondary.yaml
+# In order to get the regenerated Secret for sure, delete the existing secret if any.
+	kubectl delete secret -n $(NAMESPACE) cert-mantle || true
+# Wait until a Secret for the certificates is created.
+	until kubectl get secret -n $(NAMESPACE) cert-mantle >/dev/null ; do sleep 1; done
+# Dump ca.crt in the secret to import it to the primary cluster.
+	kubectl get secret -n $(NAMESPACE) cert-mantle -o json | jq -r '.data."ca.crt"' | base64 -d > $(TMPDIR)/secondary-ca.crt
+	$(MAKE) minikube-profile-primary
+	kubectl create cm mantle-secondary-ca-crt -n $(NAMESPACE) --from-file=ca.crt=$(TMPDIR)/secondary-ca.crt \
+		--output yaml --dry-run=client | kubectl apply -f -
 
 .PHONY: minikube-profile-primary
 minikube-profile-primary:

--- a/test/e2e/testdata/cert-primary.yaml
+++ b/test/e2e/testdata/cert-primary.yaml
@@ -1,0 +1,45 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: selfsigned-ca
+  secretName: selfsigned-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: selfsigned-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mantle
+  namespace: rook-ceph
+spec:
+  secretName: cert-mantle
+  dnsNames:
+    - mantle-primary.example.com
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/test/e2e/testdata/cert-secondary-template.yaml
+++ b/test/e2e/testdata/cert-secondary-template.yaml
@@ -1,0 +1,46 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: selfsigned-ca
+  secretName: selfsigned-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: selfsigned-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: mantle
+  namespace: rook-ceph
+spec:
+  secretName: cert-mantle
+  dnsNames:
+    - mantle-secondary.example.com
+  ipAddresses: [{ENDPOINT}]
+  issuerRef:
+    name: ca-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/test/e2e/testdata/values-mantle-primary-template.yaml
+++ b/test/e2e/testdata/values-mantle-primary-template.yaml
@@ -18,3 +18,13 @@ controller:
     - name: REQUEUE_RECONCILIATION_AFTER
       value: "1s"
   backupTransferPartSize: {BACKUP_TRANSFER_PART_SIZE}
+  #grpcTLSClientCertPath: ""
+  #grpcTLSClientKeyPath: ""
+  grpcTLSServerCAPath: "/mnt/grpc-tls-server-cert/ca.crt"
+  volumeMounts:
+    - name: grpc-tls-server-cert
+      mountPath: /mnt/grpc-tls-server-cert
+  volumes:
+    - name: grpc-tls-server-cert
+      configMap:
+        name: mantle-secondary-ca-crt

--- a/test/e2e/testdata/values-mantle-primary-template.yaml
+++ b/test/e2e/testdata/values-mantle-primary-template.yaml
@@ -18,13 +18,18 @@ controller:
     - name: REQUEUE_RECONCILIATION_AFTER
       value: "1s"
   backupTransferPartSize: {BACKUP_TRANSFER_PART_SIZE}
-  #grpcTLSClientCertPath: ""
-  #grpcTLSClientKeyPath: ""
+  grpcTLSClientCertPath: "/mnt/grpc-tls-client-cert/tls.crt"
+  grpcTLSClientKeyPath: "/mnt/grpc-tls-client-cert/tls.key"
   grpcTLSServerCAPath: "/mnt/grpc-tls-server-cert/ca.crt"
   volumeMounts:
     - name: grpc-tls-server-cert
       mountPath: /mnt/grpc-tls-server-cert
+    - name: grpc-tls-client-cert
+      mountPath: /mnt/grpc-tls-client-cert
   volumes:
     - name: grpc-tls-server-cert
       configMap:
         name: mantle-secondary-ca-crt
+    - name: grpc-tls-client-cert
+      secret:
+        secretName: cert-mantle

--- a/test/e2e/testdata/values-mantle-secondary-template.yaml
+++ b/test/e2e/testdata/values-mantle-secondary-template.yaml
@@ -17,14 +17,19 @@ controller:
       value: "1"
   grpcTLSServerCertPath: "/mnt/grpc-tls-server-cert/tls.crt"
   grpcTLSServerKeyPath: "/mnt/grpc-tls-server-cert/tls.key"
-  #grpcTLSClientCAPath: ""
+  grpcTLSClientCAPath: "/mnt/grpc-tls-client-cert/ca.crt"
   volumeMounts:
     - name: grpc-tls-server-cert
       mountPath: /mnt/grpc-tls-server-cert
+    - name: grpc-tls-client-cert
+      mountPath: /mnt/grpc-tls-client-cert
   volumes:
     - name: grpc-tls-server-cert
       secret:
         secretName: cert-mantle
+    - name: grpc-tls-client-cert
+      configMap:
+        name: mantle-primary-ca-crt
 
 secondaryService:
   type: NodePort

--- a/test/e2e/testdata/values-mantle-secondary-template.yaml
+++ b/test/e2e/testdata/values-mantle-secondary-template.yaml
@@ -15,6 +15,16 @@ controller:
   env:
     - name: REQUEUE_RECONCILIATION_IMMEDIATELY
       value: "1"
+  grpcTLSServerCertPath: "/mnt/grpc-tls-server-cert/tls.crt"
+  grpcTLSServerKeyPath: "/mnt/grpc-tls-server-cert/tls.key"
+  #grpcTLSClientCAPath: ""
+  volumeMounts:
+    - name: grpc-tls-server-cert
+      mountPath: /mnt/grpc-tls-server-cert
+  volumes:
+    - name: grpc-tls-server-cert
+      secret:
+        secretName: cert-mantle
 
 secondaryService:
   type: NodePort

--- a/versions.mk
+++ b/versions.mk
@@ -16,6 +16,8 @@ PROTOC_VERSION := 29.3
 ROOK_CHART_VERSION := v1.16.4
 # https://github.com/golangci/golangci-lint/releases
 GOLANGCI_LINT_VERSION := v1.64.5
+# https://github.com/cert-manager/cert-manager/releases
+CERT_MANAGER_VERSION := v1.17.1
 
 # Tools versions which are defined in go.mod
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
This PR allows primary and secondary mantle-controller to communicate with each other via gRPC over TLS or mTLS. It adds the following command-line arguments:

- --grpc-tls-client-cert-path
    - The file path of a TLS certificate used for client authentication of gRPC.
- --grpc-tls-client-key-path
    - The file path of a TLS key used for client authentication of gRPC.
- --grpc-tls-client-ca-path
    - The file path of a TLS CA certificate that issues a certificate used for client authentication of gRPC.
- --grpc-tls-server-cert-path
    - The file path of a TLS certificate used for server authentication of gRPC.
- --grpc-tls-server-key-path
    - The file path of a TLS key used for server authentication of gRPC.
- --grpc-tls-server-ca-path
    - The file path of a TLS CA certificate that issues a certificate used for server authentication of gRPC.

We should use these arguments as follows:

- To use plaintext:
  - None of them should be specified.
- To use TLS:
  - start primary mantle-controller with --grpc-tls-server-ca-path.
  - start secondary mantle-controller with --grpc-tls-server-cert-path and --grpc-tls-server-key-path.
- To use mTLS:
  - start primary mantle-controller with --grpc-tls-client-cert-path, --grpc-tls-client-key-path, and --grpc-tls-server-ca-path.
  - start secondary mantle-controller with --grpc-tls-client-ca-path, --grpc-tls-server-cert-path, and --grpc-tls-server-key-path.

This PR modifies test/e2e to use mTLS in the tests with the help of cert-manager. After starting minikube clusters, Certificate resources are issued by self-signed CA, and mantle-controllers use them for their gRPC connections.