### PR TITLE
Bump mantle chart version to 0.2.6

### DIFF
--- a/charts/mantle/Chart.yaml
+++ b/charts/mantle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Change log:

* charts/mantle: support injection of Deployment's annotations and labels by @ushitora-anqou in https://github.com/cybozu-go/mantle/pull/132