### PR TITLE
avoid using BinaryAssetsDirectory

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,9 +1,7 @@
 package controller
 
 import (
-	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -49,14 +47,6 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.1-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error


### PR DESCRIPTION
This is a _kaizen_. We always run the tests via `make` command, so we don't need `BinaryAssetsDirectory`.