### PR TITLE
test: set up mock before manager is started to avoid race condition

### DIFF
--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -372,11 +372,14 @@ var _ = Describe("MantleBackup controller", func() {
 			HttpsProxy: "dummy https proxy",
 			NoProxy:    "no proxy",
 		}
-		BeforeEach(func() {
+
+		It("should be synced to remote", func(ctx SpecContext) {
+			// CSATEST-1491
 			mgrUtil = testutil.NewManagerUtil(context.Background(), cfg, scheme.Scheme)
 
 			var t reporter
 			mockCtrl = gomock.NewController(t)
+			defer mockCtrl.Finish()
 			grpcClient = proto.NewMockMantleServiceClient(mockCtrl)
 			reconciler = NewMantleBackupReconciler(
 				mgrUtil.GetManager().GetClient(),
@@ -408,19 +411,6 @@ var _ = Describe("MantleBackup controller", func() {
 
 			setupExpireQueueSniffer()
 
-			mgrUtil.Start()
-			time.Sleep(100 * time.Millisecond)
-
-			ns = resMgr.CreateNamespace()
-		})
-		AfterEach(func() {
-			if mockCtrl != nil {
-				mockCtrl.Finish()
-			}
-		})
-
-		It("should be synced to remote", func(ctx SpecContext) {
-			// CSATEST-1491
 			grpcClient.EXPECT().CreateOrUpdatePVC(gomock.Any(), &customMatcherHelper{
 				// check if the PVC has the capacity equal to the fake RBD snapshot size
 				matcher: func(x any) bool {
@@ -482,6 +472,12 @@ var _ = Describe("MantleBackup controller", func() {
 					) (*proto.SetSynchronizingResponse, error) {
 						return &proto.SetSynchronizingResponse{}, nil
 					})
+
+			// Manager should be started after the mock is set up to avoid race condition.
+			mgrUtil.Start()
+			time.Sleep(100 * time.Millisecond)
+
+			ns = resMgr.CreateNamespace()
 
 			pv, pvc, err := resMgr.CreateUniquePVAndPVC(ctx, ns)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This is a _kaizen_. The unit tests, run by `make test`, sometimes fail due to the following error:

        [FAILED] Unexpected call to
        *proto.MockMantleServiceClient.CreateOrUpdatePVC([context.Background.WithCancel.WithValue(logr.contextKey,
        logr.Logger).WithValue(controller.reconcileIDKey, types.UID) pvc:
        "{\"metadata\":{\"creationTimestamp\":null,\"annotations\":
        {\"mantle.cybozu.io/remote-uid\":\"\"}},\"spec\":{\"resources\":
        {\"requests\":{\"storage\":\"5368709120\"}}},\"status\":{}}"])
        at
        /home/runner/work/mantle/mantle/internal/controller/mantlebackup_controller.go:
        580 because: there are no expected calls of the method
        "CreateOrUpdatePVC" for that receiver

This error is caused by a race between the manager startup and mock setup. This commit resolves this problem by setting up the mock first and starting the manager later.