### PR TITLE
use mantle image for for toolbox container

### DIFF
--- a/charts/mantle/templates/deployment.yaml
+++ b/charts/mantle/templates/deployment.yaml
@@ -221,7 +221,7 @@ spec:
               secretKeyRef:
                 key: ceph-username
                 name: rook-ceph-mon
-          image: ghcr.io/cybozu/ceph:18.2.4.2
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           name: toolbox
           securityContext:


### PR DESCRIPTION
Mantle image includes the Ceph packages required by the toolbox sidecar.