### PR TITLE
simplify controller logic by adding status helper methods to MantleBackup and Restore

### DIFF
--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -84,6 +85,14 @@ type MantleBackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []MantleBackup `json:"items"`
+}
+
+func (m *MantleBackup) IsReady() bool {
+	return meta.IsStatusConditionTrue(m.Status.Conditions, BackupConditionReadyToUse)
+}
+
+func (m *MantleBackup) IsSynced() bool {
+	return meta.IsStatusConditionTrue(m.Status.Conditions, BackupConditionSyncedToRemote)
 }
 
 func init() {

--- a/api/v1/mantlerestore_types.go
+++ b/api/v1/mantlerestore_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,6 +51,10 @@ type MantleRestore struct {
 
 	Spec   MantleRestoreSpec   `json:"spec,omitempty"`
 	Status MantleRestoreStatus `json:"status,omitempty"`
+}
+
+func (m *MantleRestore) IsReady() bool {
+	return meta.IsStatusConditionTrue(m.Status.Conditions, RestoreConditionReadyToUse)
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -130,7 +130,7 @@ var _ = Describe("MantleBackup controller", func() {
 			err := k8sClient.Get(ctx, namespacedName, backup)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(
-				meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse),
+				backup.IsReady(),
 			).To(BeFalse())
 		}, "10s", "1s").Should(Succeed())
 	}
@@ -1770,7 +1770,7 @@ var _ = Describe("import", func() {
 
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: backup.GetName(), Namespace: backup.GetNamespace()}, backup)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)).To(BeTrue())
+			Expect(backup.IsReady()).To(BeTrue())
 			Expect(*backup.Status.SnapID).To(Equal(dummySnapshot.Id))
 		})
 	})
@@ -1920,7 +1920,7 @@ var _ = Describe("import", func() {
 			Expect(ok).To(BeFalse())
 
 			// Check that SyncedToRemote is set True
-			Expect(meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)).To(BeTrue())
+			Expect(backup.IsSynced()).To(BeTrue())
 
 			// Check that the Jobs are deleted
 			checkExportAndUploadJobsDeleted(ctx, backup)
@@ -1949,7 +1949,7 @@ var _ = Describe("import", func() {
 			Expect(res.IsZero()).To(BeTrue())
 
 			// SyncedToRemote should NOT be true.
-			Expect(meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)).To(BeFalse())
+			Expect(backup.IsSynced()).To(BeFalse())
 		})
 
 		It("should not delete unrelated resources", func(ctx SpecContext) {

--- a/internal/controller/mantlerestore_controller.go
+++ b/internal/controller/mantlerestore_controller.go
@@ -89,7 +89,7 @@ func (r *MantleRestoreReconciler) restore(ctx context.Context, restore *mantlev1
 	logger.Info("restoring", "backup", restore.Spec.Backup)
 
 	// skip if already ReadyToUse
-	if meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse) {
+	if restore.IsReady() {
 		return ctrl.Result{}, nil
 	}
 
@@ -136,7 +136,7 @@ func (r *MantleRestoreReconciler) restore(ctx context.Context, restore *mantlev1
 	}
 
 	// check if the backup is ReadyToUse
-	if !meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
+	if !backup.IsReady() {
 		logger.Info("backup is not ready to use", "backup", backup.Name, "namespace", backup.Namespace)
 		return requeueReconciliation(), nil
 	}

--- a/internal/controller/replication.go
+++ b/internal/controller/replication.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cybozu-go/mantle/pkg/controller/proto"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -231,7 +230,7 @@ func (s *SecondaryServer) SetSynchronizing(
 		return nil, err
 	}
 
-	if meta.IsStatusConditionTrue(target.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
+	if target.IsReady() {
 		return nil, errors.New("ReadyToUse is true")
 	}
 

--- a/internal/testutil/resources.go
+++ b/internal/testutil/resources.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -219,7 +218,7 @@ func (r *ResourceManager) WaitForBackupReady(ctx context.Context, backup *mantle
 		err := r.client.Get(ctx, types.NamespacedName{Name: backup.Name, Namespace: backup.Namespace}, backup)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse)).Should(BeTrue())
+		g.Expect(backup.IsReady()).Should(BeTrue())
 	}).WithContext(ctx).Should(Succeed())
 }
 
@@ -228,7 +227,7 @@ func (r *ResourceManager) WaitForBackupSyncedToRemote(ctx context.Context, backu
 		err := r.client.Get(ctx, types.NamespacedName{Name: backup.Name, Namespace: backup.Namespace}, backup)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)).Should(BeTrue())
+		g.Expect(backup.IsSynced()).Should(BeTrue())
 	}).WithContext(ctx).Should(Succeed())
 }
 

--- a/test/e2e/multik8s/full_backup_test.go
+++ b/test/e2e/multik8s/full_backup_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -113,7 +112,7 @@ var _ = Describe("full backup", Label("full-backup"), func() {
 				if secondaryMB.Status.CreatedAt.IsZero() {
 					return errors.New(".Status.CreatedAt is zero")
 				}
-				if !meta.IsStatusConditionTrue(secondaryMB.Status.Conditions, "ReadyToUse") {
+				if !secondaryMB.IsReady() {
 					return errors.New("ReadyToUse of .Status.Conditions is not True")
 				}
 

--- a/test/e2e/multik8s/misc_test.go
+++ b/test/e2e/multik8s/misc_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 var _ = Describe("miscellaneous tests", func() {
@@ -94,8 +93,8 @@ var _ = Describe("miscellaneous tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		WaitTemporaryResourcesDeleted(ctx, primaryMB2, secondaryMB2)
 
-		Expect(meta.IsStatusConditionTrue(secondaryMB1.Status.Conditions, "ReadyToUse")).To(BeTrue())
-		Expect(meta.IsStatusConditionTrue(secondaryMB2.Status.Conditions, "ReadyToUse")).To(BeTrue())
+		Expect(secondaryMB1.IsReady()).To(BeTrue())
+		Expect(secondaryMB2.IsReady()).To(BeTrue())
 
 		snap, err := FindRBDSnapshotInPVC(SecondaryK8sCluster, namespace, pvcName1, backupName1)
 		Expect(err).NotTo(HaveOccurred())
@@ -154,8 +153,7 @@ s5cmd(){
 			Eventually(ctx, func(g Gomega) {
 				primaryMB, err := GetMB(PrimaryK8sCluster, namespace, backupName)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(meta.IsStatusConditionTrue(primaryMB.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)).
-					To(BeFalse())
+				g.Expect(primaryMB.IsSynced()).To(BeFalse())
 
 				jobSlow, err := GetJob(PrimaryK8sCluster, CephClusterNamespace,
 					controller.MakeUploadJobName(primaryMB, partNumSlow))
@@ -234,8 +232,7 @@ s5cmd(){
 			Eventually(ctx, func(g Gomega) {
 				primaryMB, err := GetMB(PrimaryK8sCluster, namespace, backupName)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(meta.IsStatusConditionTrue(primaryMB.Status.Conditions, mantlev1.BackupConditionSyncedToRemote)).
-					To(BeFalse())
+				g.Expect(primaryMB.IsSynced()).To(BeFalse())
 
 				backup, err = GetMB(clusterOfJob, namespace, backupName)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -25,7 +25,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -495,7 +494,7 @@ func WaitMantleBackupReadyToUse(cluster int, namespace, backupName string) {
 		if err != nil {
 			return err
 		}
-		if !meta.IsStatusConditionTrue(mb.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
+		if !mb.IsReady() {
 			return errors.New("status of ReadyToUse condition is not True")
 		}
 		return nil
@@ -510,7 +509,7 @@ func WaitMantleBackupSynced(namespace, backupName string) {
 		if err != nil {
 			return err
 		}
-		if !meta.IsStatusConditionTrue(mb.Status.Conditions, mantlev1.BackupConditionSyncedToRemote) {
+		if !mb.IsSynced() {
 			return errors.New("status of SyncedToRemote condition is not True")
 		}
 		return nil
@@ -557,7 +556,7 @@ func EnsureCorrectRestoration(
 	Eventually(ctx, func(g Gomega) {
 		mr, err := GetMR(clusterNo, namespace, restoreName)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(meta.IsStatusConditionTrue(mr.Status.Conditions, "ReadyToUse")).To(BeTrue())
+		g.Expect(mr.IsReady()).To(BeTrue())
 	}).Should(Succeed())
 	By(fmt.Sprintf("%s: %s: checking the MantleRestore has the correct contents", clusterName, backupName))
 	Eventually(ctx, func(g Gomega) {

--- a/test/e2e/singlek8s/restore_test.go
+++ b/test/e2e/singlek8s/restore_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -196,7 +195,7 @@ func (test *restoreTest) testRestore() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("checking if the status is updated")
-		Expect(meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)).To(BeTrue())
+		Expect(restore.IsReady()).To(BeTrue())
 	})
 
 	It("should not update clone image if it is already created", func() {
@@ -439,7 +438,7 @@ func (test *restoreTest) testCloneImageFromBackup() {
 				return err
 			}
 
-			if !meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse) {
+			if !backup.IsReady() {
 				return fmt.Errorf("backup is not ready")
 			}
 			return nil

--- a/test/e2e/singlek8s/util.go
+++ b/test/e2e/singlek8s/util.go
@@ -15,7 +15,6 @@ import (
 	testutil "github.com/cybozu-go/mantle/test/util"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/yaml"
 )
 
@@ -395,7 +394,7 @@ func isMantleBackupReady(namespace, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return meta.IsStatusConditionTrue(backup.Status.Conditions, mantlev1.BackupConditionReadyToUse), nil
+	return backup.IsReady(), nil
 }
 
 func isMantleRestoreReady(namespace, name string) bool {
@@ -413,7 +412,7 @@ func isMantleRestoreReady(namespace, name string) bool {
 	if restore.Status.Conditions == nil {
 		return false
 	}
-	return meta.IsStatusConditionTrue(restore.Status.Conditions, mantlev1.RestoreConditionReadyToUse)
+	return restore.IsReady()
 }
 
 func writeTestData(namespace, pvc string, data []byte) error {


### PR DESCRIPTION
simplify controller logic by adding status helper methods to MantleBackup and Restore.