### PR TITLE
remove mantle_backup_duration_seconds_total metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,6 @@ make undeploy
 
 ## Prometheus metrics
 
-### `mantle_backup_duration_seconds_total`
-
-`mantle_backup_duration_seconds_total` is a Counter that indicates the time from the creationTimestamp to the completion of the backup.
-
-| Label                   | Description             |
-| ----------------------- | ----------------------- |
-| `persistentvolumeclaim` | The PVC name.           |
-| `resource_namespace`    | The resource namespace. |
-
 ### `mantle_mantlebackupconfig_info`
 
 `mantle_mantlebackupconfig_info` is a Gauge that indicates information about the backup configuration.

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -2419,11 +2419,6 @@ func (r *MantleBackupReconciler) primaryCleanup(
 	}
 
 	duration := time.Since(target.GetCreationTimestamp().Time).Seconds()
-	metrics.BackupDurationSecondsTotal.With(prometheus.Labels{
-		"persistentvolumeclaim": target.Spec.PVC,
-		"resource_namespace":    target.GetNamespace(),
-	}).Add(float64(duration))
-
 	metrics.BackupDurationSeconds.With(prometheus.Labels{
 		"persistentvolumeclaim": target.Spec.PVC,
 		"resource_namespace":    target.GetNamespace(),

--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -8,15 +8,6 @@ import (
 const namespace = "mantle"
 
 var (
-	BackupDurationSecondsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Name:      "backup_duration_seconds_total",
-			Help:      "The time from the creationTimestamp to the completion of the backup.",
-		},
-		[]string{"persistentvolumeclaim", "resource_namespace"},
-	)
-
 	BackupConfigInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -38,7 +29,6 @@ var (
 )
 
 func init() {
-	runtimemetrics.Registry.MustRegister(BackupDurationSecondsTotal)
 	runtimemetrics.Registry.MustRegister(BackupConfigInfo)
 	runtimemetrics.Registry.MustRegister(BackupDurationSeconds)
 }

--- a/test/e2e/multik8s/misc_test.go
+++ b/test/e2e/multik8s/misc_test.go
@@ -38,7 +38,6 @@ var _ = Describe("metrics tests", func() {
 				g.Expect(strings.Contains(string(stdout), metricName)).To(BeTrue())
 			}).Should(Succeed())
 		},
-		Entry(`mantle_backup_duration_seconds_total`, `mantle_backup_duration_seconds_total`),
 		Entry(`mantle_mantlebackupconfig_info`, `mantle_mantlebackupconfig_info`),
 		Entry(`mantle_backup_duration_seconds_bucket`, `mantle_backup_duration_seconds_bucket`),
 		Entry(`mantle_backup_duration_seconds_sum`, `mantle_backup_duration_seconds_sum`),


### PR DESCRIPTION
The values of the metric mantle_backup_duration_seconds_total always are
the same as those of mantle_backup_duration_seconds_sum, so we don't
need it. This commit removes mantle_backup_duration_seconds_total.