### PR TITLE
restore: zero out the restore volume correctly

### DIFF
--- a/ceph/test/cluster/block.go
+++ b/ceph/test/cluster/block.go
@@ -11,11 +11,11 @@ import (
 	"github.com/cybozu-go/mantle/test/util"
 )
 
-func DiscardBlock(namespace, deployName string) error {
+func ZeroOutBlock(namespace, deployName string) error {
 	_, err := Kubectl("exec", "-n", namespace, "deploy/"+deployName, "--",
-		"blkdiscard", "/dev/rbd-device")
+		"blkdiscard", "-z", "/dev/rbd-device")
 	if err != nil {
-		return fmt.Errorf("failed to discard volume: %w", err)
+		return fmt.Errorf("failed to zero out volume: %w", err)
 	}
 	return nil
 }

--- a/ceph/test/content_test.go
+++ b/ceph/test/content_test.go
@@ -111,8 +111,8 @@ func (t *contentTest) createSnapshot() {
 		err = cluster.GetBlockAsFile(t.namespace, t.srcDeployName, t.snapshots[3])
 		Expect(err).NotTo(HaveOccurred())
 
-		// snapshot4 has discard volume
-		err = cluster.DiscardBlock(t.namespace, t.srcDeployName)
+		// snapshot4 has zero-filled volume
+		err = cluster.ZeroOutBlock(t.namespace, t.srcDeployName)
 		Expect(err).NotTo(HaveOccurred())
 		err = cluster.SnapCreate(t.poolName, t.srcImageName, t.snapshots[4])
 		Expect(err).NotTo(HaveOccurred())
@@ -394,7 +394,7 @@ func (t *contentTest) test() {
 				rollbackTo: "snapshot3-offset-1024",
 			},
 			{
-				description:      "(228) discard data area between snapshots, offset + length == rbd volume size",
+				description:      "(228) zero out data area between snapshots, offset + length == rbd volume size",
 				expectedDataName: t.snapshots[4],
 				importsBefore:    []string{"/tmp/snapshot3.bin", "/tmp/snapshot4-offset-1Mi.bin"},
 				exportArgs: []string{
@@ -407,7 +407,7 @@ func (t *contentTest) test() {
 				rollbackTo: "snapshot4-offset-1048576",
 			},
 			{
-				description:      "(229) discard data area between snapshots, offset + length > rbd volume size",
+				description:      "(229) zero out data area between snapshots, offset + length > rbd volume size",
 				expectedDataName: t.snapshots[4],
 				importsBefore:    []string{"/tmp/snapshot3.bin", "/tmp/snapshot4-offset-1Mi.bin"},
 				exportArgs: []string{

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -810,7 +810,7 @@ func WaitTemporarySecondaryJobsDeleted(ctx SpecContext, secondaryMB *mantlev1.Ma
 	WaitComponentJobsDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace,
 		controller.MantleImportJobPrefix, secondaryMB)
 	WaitComponentJobsDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace,
-		controller.MantleDiscardJobPrefix, secondaryMB)
+		controller.MantleZeroOutJobPrefix, secondaryMB)
 }
 
 func WaitTemporaryJobsDeleted(ctx SpecContext, primaryMB, secondaryMB *mantlev1.MantleBackup) {
@@ -853,7 +853,7 @@ func WaitTemporaryPrimaryPVCsDeleted(ctx SpecContext, primaryMB *mantlev1.Mantle
 
 func WaitTemporarySecondaryPVCsDeleted(ctx SpecContext, secondaryMB *mantlev1.MantleBackup) {
 	GinkgoHelper()
-	WaitPVCDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace, controller.MakeDiscardPVCName(secondaryMB))
+	WaitPVCDeleted(ctx, SecondaryK8sCluster, CephClusterNamespace, controller.MakeZeroOutPVCName(secondaryMB))
 }
 
 func WaitTemporaryPVCsDeleted(ctx SpecContext, primaryMB, secondaryMB *mantlev1.MantleBackup) {
@@ -877,7 +877,7 @@ func WaitPVDeleted(ctx SpecContext, cluster int, pvName string) {
 
 func WaitTemporarySecondaryPVsDeleted(ctx SpecContext, secondaryMB *mantlev1.MantleBackup) {
 	GinkgoHelper()
-	WaitPVDeleted(ctx, SecondaryK8sCluster, controller.MakeDiscardPVName(secondaryMB))
+	WaitPVDeleted(ctx, SecondaryK8sCluster, controller.MakeZeroOutPVName(secondaryMB))
 }
 
 func WaitTemporaryS3ObjectsDeleted(ctx SpecContext, primaryMB *mantlev1.MantleBackup) {

--- a/test/e2e/singlek8s/backup_test.go
+++ b/test/e2e/singlek8s/backup_test.go
@@ -180,10 +180,10 @@ func (test *backupTest) testCase1() {
 			Expect(strings.HasPrefix(job.GetName(), controller.MantleExportJobPrefix)).To(BeFalse())
 			Expect(strings.HasPrefix(job.GetName(), controller.MantleUploadJobPrefix)).To(BeFalse())
 			Expect(strings.HasPrefix(job.GetName(), controller.MantleImportJobPrefix)).To(BeFalse())
-			Expect(strings.HasPrefix(job.GetName(), controller.MantleDiscardJobPrefix)).To(BeFalse())
+			Expect(strings.HasPrefix(job.GetName(), controller.MantleZeroOutJobPrefix)).To(BeFalse())
 		}
 
-		// Check that export and discard PVC are not created.
+		// Check that export and zeroout PVC are not created.
 		stdout, _, err = kubectl("-n", cephCluster1Namespace, "get", "pvc", "-o", "json")
 		Expect(err).NotTo(HaveOccurred())
 		var pvcs corev1.PersistentVolumeClaimList
@@ -191,17 +191,17 @@ func (test *backupTest) testCase1() {
 		Expect(err).NotTo(HaveOccurred())
 		for _, pvc := range pvcs.Items {
 			Expect(strings.HasPrefix(pvc.GetName(), controller.MantleExportDataPVCPrefix)).To(BeFalse())
-			Expect(strings.HasPrefix(pvc.GetName(), controller.MantleDiscardPVCPrefix)).To(BeFalse())
+			Expect(strings.HasPrefix(pvc.GetName(), controller.MantleZeroOutPVCPrefix)).To(BeFalse())
 		}
 
-		// Check that discard PV is not created.
+		// Check that zeroout PV is not created.
 		stdout, _, err = kubectl("-n", cephCluster1Namespace, "get", "pv", "-o", "json")
 		Expect(err).NotTo(HaveOccurred())
 		var pvs corev1.PersistentVolumeList
 		err = json.Unmarshal(stdout, &pvs)
 		Expect(err).NotTo(HaveOccurred())
 		for _, pv := range pvs.Items {
-			Expect(strings.HasPrefix(pv.GetName(), controller.MantleDiscardPVPrefix)).To(BeFalse())
+			Expect(strings.HasPrefix(pv.GetName(), controller.MantleZeroOutPVPrefix)).To(BeFalse())
 		}
 	})
 


### PR DESCRIPTION
We've used `blkdiscard` to zero out the restore volume. However, it doesn't guarantee this behavior. We should use `blkdiscard -z` in this case.

Now `discard job` doesn't explain the role of this job, let's rename it to `zeroout` job.