### PR TITLE
replace CreateOrUpdate with Update if create never happens

### DIFF
--- a/internal/controller/replication.go
+++ b/internal/controller/replication.go
@@ -267,33 +267,31 @@ func (s *SecondaryServer) SetSynchronizing(
 			return nil, errors.New("diffTo is invalid")
 		}
 
-		if _, err := ctrl.CreateOrUpdate(ctx, s.client, &source, func() error {
-			annot := source.GetAnnotations()
-			if annot == nil {
-				annot = map[string]string{}
-			}
-			annot[annotDiffTo] = req.Name
-			source.SetAnnotations(annot)
-			return nil
-		}); err != nil {
+		annot := source.GetAnnotations()
+		if annot == nil {
+			annot = map[string]string{}
+		}
+		annot[annotDiffTo] = req.Name
+		source.SetAnnotations(annot)
+
+		if err := s.client.Update(ctx, &source); err != nil {
 			return nil, err
 		}
 	}
 
-	if _, err := ctrl.CreateOrUpdate(ctx, s.client, &target, func() error {
-		annot := target.GetAnnotations()
-		if annot == nil {
-			annot = map[string]string{}
-		}
-		if req.DiffFrom == nil {
-			annot[annotSyncMode] = syncModeFull
-		} else {
-			annot[annotSyncMode] = syncModeIncremental
-			annot[annotDiffFrom] = *req.DiffFrom
-		}
-		target.SetAnnotations(annot)
-		return nil
-	}); err != nil {
+	annot := target.GetAnnotations()
+	if annot == nil {
+		annot = map[string]string{}
+	}
+	if req.DiffFrom == nil {
+		annot[annotSyncMode] = syncModeFull
+	} else {
+		annot[annotSyncMode] = syncModeIncremental
+		annot[annotDiffFrom] = *req.DiffFrom
+	}
+	target.SetAnnotations(annot)
+
+	if err := s.client.Update(ctx, &target); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Some `CreateOrUpdate` calls violate the following prerequisite.

https://github.com/kubernetes-sigs/controller-runtime/blob/961fc2c233d64e40b5bdf449f12bfa22cf2d7b28/pkg/controller/controllerutil/controllerutil.go#L312-L313

Let's fix this bug by replacing `CreateOrUpdate` with `Update`.