### PR TITLE
e2e: try to load both kvm modules for Intel and AMD

### DIFF
--- a/.github/actions/set-up-kvm-for-e2e-tests/action.yaml
+++ b/.github/actions/set-up-kvm-for-e2e-tests/action.yaml
@@ -23,7 +23,5 @@ runs:
            sudo chmod 777 /var/run/libvirt/libvirt-sock
            sudo ls -la /var/run/libvirt/libvirt-sock
            ls -l /dev/kvm
-           sudo rmmod kvm_amd
-           sudo rmmod kvm
-           sudo modprobe -a kvm
-           sudo modprobe -a kvm_amd
+           # x86 GitHub Runner can be one of Intel and AMD, so try both.
+           sudo modprobe -a kvm_intel || sudo modprobe -a kvm_amd


### PR DESCRIPTION
We should not assume our runner is surely running on top of AMD machine. It's safe to try to load kvm modules for both CPUs.

ref.
https://github.com/cybozu-go/fin/pull/154

In addition, avoid unloading these modules beforehand. Probably it's not necessary.