### PR TITLE
test: support do-not-merge label

### DIFF
--- a/.github/workflows/check-do-not-merge.yaml
+++ b/.github/workflows/check-do-not-merge.yaml
@@ -1,0 +1,17 @@
+name: Check Do Not Merge Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for do-not-merge label
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}" == "true" ]]; then
+            echo "::error::This PR has the 'do-not-merge' label and cannot be merged"
+            exit 1
+          fi
+          echo "No blocking labels found"


### PR DESCRIPTION
Support do-not-merge label for PR. PR can't be merged if this label is set. The use cases of this label are to prohibit PRs that are needs to be rebased or squashed.

I'll change the setup to use this workflow later.

ref.
https://github.com/topolvm/topolvm/blob/c4eacf5bbaa818d0b8f548f7c2905cbeed7d3dd9/.github/workflows/pr-labeled.yaml