### PR TITLE
BREAKING CHANGE: rename ReadyToUse to SnapshotCaptured

### DIFF
--- a/api/v1/mantlebackup_types.go
+++ b/api/v1/mantlebackup_types.go
@@ -57,12 +57,12 @@ type MantleBackupStatus struct {
 }
 
 const (
-	BackupConditionReadyToUse     = "ReadyToUse"
-	BackupConditionSyncedToRemote = "SyncedToRemote"
-	BackupConditionVerified       = "Verified"
+	BackupConditionSnapshotCaptured = "SnapshotCaptured"
+	BackupConditionSyncedToRemote   = "SyncedToRemote"
+	BackupConditionVerified         = "Verified"
 
-	// Reasons for ConditionReadyToUse
-	ConditionReasonReadyToUseNoProblem = "NoProblem"
+	// Reasons for ConditionSnapshotCaptured
+	ConditionReasonSnapshotCapturedNoProblem = "NoProblem"
 	// Reasons for ConditionSyncedToRemote
 	ConditionReasonSyncedToRemoteNoProblem = "NoProblem"
 	// Reasons for ConditionVerified
@@ -93,8 +93,8 @@ type MantleBackupList struct {
 	Items           []MantleBackup `json:"items"`
 }
 
-func (m *MantleBackup) IsReady() bool {
-	return meta.IsStatusConditionTrue(m.Status.Conditions, BackupConditionReadyToUse)
+func (m *MantleBackup) IsSnapshotCaptured() bool {
+	return meta.IsStatusConditionTrue(m.Status.Conditions, BackupConditionSnapshotCaptured)
 }
 
 func (m *MantleBackup) IsSynced() bool {

--- a/docs/design.md
+++ b/docs/design.md
@@ -134,8 +134,8 @@ spec:
   expire: 2w # when the MantleBackup should expire.
 status:
   conditions:
-    # The corresponding backup data is ready to use if `status` is "True"
-    - type: "ReadyToUse"
+    # The corresponding backup data has been captured if `status` is "True".
+    - type: "SnapshotCaptured"
       status: "True"
 ```
 

--- a/internal/controller/mantlerestore_controller.go
+++ b/internal/controller/mantlerestore_controller.go
@@ -145,9 +145,9 @@ func (r *MantleRestoreReconciler) restore(ctx context.Context, restore *mantlev1
 		return ctrl.Result{}, err
 	}
 
-	// check if the backup is ReadyToUse
-	if !backup.IsReady() {
-		logger.Info("backup is not ready to use", "backup", backup.Name, "namespace", backup.Namespace)
+	// check if the backup is SnapshotCaptured
+	if !backup.IsSnapshotCaptured() {
+		logger.Info("snapshot is not captured", "backup", backup.Name, "namespace", backup.Namespace)
 
 		return requeueReconciliation(), nil
 	}

--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -86,8 +86,8 @@ func (test *mantleRestoreControllerUnitTest) setupEnv() {
 		test.backup, err = resMgr.CreateUniqueBackupFor(ctx, test.srcPVC)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("waiting for the backup to be ready")
-		resMgr.WaitForBackupReady(ctx, test.backup)
+		By("waiting for the backup to be captured")
+		resMgr.WaitForBackupSnapshotCaptured(ctx, test.backup)
 	})
 }
 

--- a/internal/controller/replication.go
+++ b/internal/controller/replication.go
@@ -232,8 +232,8 @@ func (s *SecondaryServer) SetSynchronizing(
 		return nil, err
 	}
 
-	if target.IsReady() {
-		return nil, errors.New("ReadyToUse is true")
+	if target.IsSnapshotCaptured() {
+		return nil, errors.New("SnapshotCaptured is true")
 	}
 
 	// make sure sync-mode is correct.

--- a/internal/testutil/resources.go
+++ b/internal/testutil/resources.go
@@ -215,12 +215,12 @@ func (r *ResourceManager) CreateUniqueBackupFor(ctx context.Context, pvc *corev1
 	return backup, nil
 }
 
-func (r *ResourceManager) WaitForBackupReady(ctx context.Context, backup *mantlev1.MantleBackup) {
+func (r *ResourceManager) WaitForBackupSnapshotCaptured(ctx context.Context, backup *mantlev1.MantleBackup) {
 	EventuallyWithOffset(1, func(g Gomega, ctx context.Context) {
 		err := r.client.Get(ctx, types.NamespacedName{Name: backup.Name, Namespace: backup.Namespace}, backup)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		g.Expect(backup.IsReady()).Should(BeTrue())
+		g.Expect(backup.IsSnapshotCaptured()).Should(BeTrue())
 	}).WithContext(ctx).Should(Succeed())
 }
 

--- a/test/e2e/multik8s/change_to_primary_test.go
+++ b/test/e2e/multik8s/change_to_primary_test.go
@@ -24,7 +24,7 @@ var _ = Describe("change role from primary to standalone during full backup", La
 		CreatePVC(ctx, PrimaryK8sCluster, namespace, pvcName)
 		writtenDataHash := WriteRandomDataToPV(ctx, PrimaryK8sCluster, namespace, pvcName)
 		CreateMantleBackup(PrimaryK8sCluster, namespace, pvcName, backupName)
-		WaitMantleBackupReadyToUse(PrimaryK8sCluster, namespace, backupName)
+		WaitMantleBackupSnapshotCaptured(PrimaryK8sCluster, namespace, backupName)
 
 		By("changing the primary mantle to standalone")
 		err := ChangeClusterRole(PrimaryK8sCluster, controller.RoleStandalone)

--- a/test/e2e/multik8s/change_to_secondary_test.go
+++ b/test/e2e/multik8s/change_to_secondary_test.go
@@ -76,7 +76,7 @@ var _ = Describe("change to secondary", Label("change-to-secondary"), func() {
 		CreatePVC(ctx, SecondaryK8sCluster, namespace, pvcName1)
 		writtenDataHash10 = WriteRandomDataToPV(ctx, SecondaryK8sCluster, namespace, pvcName1)
 		CreateMantleBackup(SecondaryK8sCluster, namespace, pvcName1, backupName10)
-		WaitMantleBackupReadyToUse(SecondaryK8sCluster, namespace, backupName10)
+		WaitMantleBackupSnapshotCaptured(SecondaryK8sCluster, namespace, backupName10)
 		WaitMantleBackupVerified(SecondaryK8sCluster, namespace, backupName10)
 	})
 

--- a/test/e2e/multik8s/full_backup_test.go
+++ b/test/e2e/multik8s/full_backup_test.go
@@ -112,8 +112,8 @@ var _ = Describe("full backup", Label("full-backup"), func() {
 				if secondaryMB.Status.CreatedAt.IsZero() {
 					return errors.New(".Status.CreatedAt is zero")
 				}
-				if !secondaryMB.IsReady() {
-					return errors.New("ReadyToUse of .Status.Conditions is not True")
+				if !secondaryMB.IsSnapshotCaptured() {
+					return errors.New("SnapshotCaptured of .Status.Conditions is not True")
 				}
 
 				// Check if snapshots are created correctly in the secondary Rook/Ceph cluster

--- a/test/e2e/multik8s/misc_test.go
+++ b/test/e2e/multik8s/misc_test.go
@@ -125,8 +125,8 @@ var _ = Describe("miscellaneous tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		WaitTemporaryResourcesDeleted(ctx, primaryMB2, secondaryMB2)
 
-		Expect(secondaryMB1.IsReady()).To(BeTrue())
-		Expect(secondaryMB2.IsReady()).To(BeTrue())
+		Expect(secondaryMB1.IsSnapshotCaptured()).To(BeTrue())
+		Expect(secondaryMB2.IsSnapshotCaptured()).To(BeTrue())
 
 		snap, err := FindRBDSnapshotInPVC(SecondaryK8sCluster, namespace, pvcName1, backupName1)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -534,16 +534,16 @@ func CreateMantleBackupConfig(cluster int, namespace, pvcName, backupConfigName 
 	}).Should(Succeed())
 }
 
-func WaitMantleBackupReadyToUse(cluster int, namespace, backupName string) {
+func WaitMantleBackupSnapshotCaptured(cluster int, namespace, backupName string) {
 	GinkgoHelper()
-	By("checking MantleBackup's ReadyToUse status")
+	By("checking MantleBackup's SnapshotCaptured status")
 	Eventually(func() error {
 		mb, err := GetMB(cluster, namespace, backupName)
 		if err != nil {
 			return err
 		}
-		if !mb.IsReady() {
-			return errors.New("status of ReadyToUse condition is not True")
+		if !mb.IsSnapshotCaptured() {
+			return errors.New("status of SnapshotCaptured condition is not True")
 		}
 
 		return nil

--- a/test/e2e/singlek8s/backup_test.go
+++ b/test/e2e/singlek8s/backup_test.go
@@ -156,14 +156,14 @@ func (test *backupTest) testCase1() {
 			return checkSnapshotExist(cephCluster1Namespace, test.poolName, imageName, test.mantleBackupName3)
 		}).Should(Succeed())
 
-		By("Checking that the status.conditions of the MantleBackup resource becomes \"ReadyToUse\"")
+		By("Checking that the status.conditions of the MantleBackup resource becomes \"SnapshotCaptured\"")
 		Eventually(func() error {
-			ready, err := isMantleBackupReady(test.tenantNamespace, test.mantleBackupName3)
+			captured, err := isMantleBackupSnapshotCaptured(test.tenantNamespace, test.mantleBackupName3)
 			if err != nil {
 				return err
 			}
-			if !ready {
-				return errors.New("not ready")
+			if !captured {
+				return errors.New("not captured")
 			}
 
 			return nil
@@ -225,10 +225,10 @@ func (test *backupTest) testCase1() {
 			return fmt.Errorf("PVC %s still exists. stdout: %s", test.pvcName2, stdout)
 		}).Should(Succeed())
 
-		By("Checking that the status.conditions of the MantleBackup resource remain \"ReadyToUse\"")
-		ready, err := isMantleBackupReady(test.tenantNamespace, test.mantleBackupName3)
+		By("Checking that the status.conditions of the MantleBackup resource remain \"SnapshotCaptured\"")
+		captured, err := isMantleBackupSnapshotCaptured(test.tenantNamespace, test.mantleBackupName3)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ready).To(BeTrue())
+		Expect(captured).To(BeTrue())
 	})
 
 	It("should delete MantleBackup resource", func() {

--- a/test/e2e/singlek8s/restore_test.go
+++ b/test/e2e/singlek8s/restore_test.go
@@ -122,7 +122,7 @@ func (test *restoreTest) testRestore() {
 		}).Should(BeTrue())
 	})
 
-	It("should wait for the MantleBackup to be ReadyToUse", func() {
+	It("should wait for the MantleBackup to be SnapshotCaptured", func() {
 		test.cleanup()
 
 		err := applyMantleBackupTemplate(test.tenantNamespace, test.pvcName, test.mantleBackupName1)
@@ -459,8 +459,8 @@ func (test *restoreTest) testCloneImageFromBackup() {
 				return err
 			}
 
-			if !backup.IsReady() {
-				return errors.New("backup is not ready")
+			if !backup.IsSnapshotCaptured() {
+				return errors.New("backup is not captured")
 			}
 
 			return nil

--- a/test/e2e/singlek8s/util.go
+++ b/test/e2e/singlek8s/util.go
@@ -406,7 +406,7 @@ func getRBDInfo(clusterNS, pool, image string) (*rbdInfo, error) {
 	return &info, nil
 }
 
-func isMantleBackupReady(namespace, name string) (bool, error) {
+func isMantleBackupSnapshotCaptured(namespace, name string) (bool, error) {
 	stdout, _, err := kubectl("-n", namespace, "get", "mantlebackup", name, "-o", "json")
 	if err != nil {
 		return false, err
@@ -417,7 +417,7 @@ func isMantleBackupReady(namespace, name string) (bool, error) {
 		return false, err
 	}
 
-	return backup.IsReady(), nil
+	return backup.IsSnapshotCaptured(), nil
 }
 
 func isMantleRestoreReady(namespace, name string) bool {


### PR DESCRIPTION
~~Don't merge this PR until the release process is completed.~~ **This PR has a breaking change**, so please release and deploy it carefully. ~~In addition, this PR should be merged after #197 is merged.~~ done.

~~This PR should be merged after #220.~~ Done.

This commit renames MantleBackup's ReadyToUse condition to
SnapshotCaptured. This is a breaking change; before deploying it, users
should stop all of the mantle-controller Pods in the primary and
secondary clusters, patch the conditions by hand, and then start the new
controller.