### PR TITLE
cleanup resources after backup completes

### DIFF
--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -1902,7 +1902,7 @@ var _ = Describe("import", func() {
 			checkPVCDeleted(ctx, MakeExportDataPVCName(backup, 0))
 		}
 
-		It("should delete annotations, Jobs, and PVCs, and update SyncedToRemote", func(ctx SpecContext) {
+		It("should delete annotations, Jobs, and PVCs", func(ctx SpecContext) {
 			// Create source MantleBackup
 			source, err := createMantleBackupUsingDummyPVC(ctx, "source", ns)
 			Expect(err).NotTo(HaveOccurred())
@@ -1941,9 +1941,6 @@ var _ = Describe("import", func() {
 			Expect(err).NotTo(HaveOccurred())
 			_, ok = source.GetAnnotations()[annotDiffTo]
 			Expect(ok).To(BeFalse())
-
-			// Check that SyncedToRemote is set True
-			Expect(backup.IsSynced()).To(BeTrue())
 
 			// Check that the Jobs are deleted
 			checkExportAndUploadJobsDeleted(ctx, backup)


### PR DESCRIPTION
~~Don't merge this PR until the release process is completed.~~ This PR now includes no breaking changes, so it can be safely released.

This PR prepares for the introduction of verification.

In the current code, we call primaryCleanup in `replicate`, and it sets SyncedToRemote=True after cleaning up all temporary resources.

According to the newer version of the specification, we've changed this code in this PR. `replicate` now directly sets `SyncedToRemote=True` without calling `primaryCleanup`. Instead, `primaryCleanup` is called in `reconcileAsStandalone` and `reconcileAsPrimary`.
