### PR TITLE
charts: fix appVersion for chart v0.3.8

### DIFF
--- a/charts/mantle/Chart.yaml
+++ b/charts/mantle/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.3.8
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.0"
+appVersion: "0.8.1"


### PR DESCRIPTION
Since app v0.8.0 contains a bug, we should use 0.8.1.

Fortunately, since the Release Charts action has not been executed yet, we can simply overwrite the app version.