### PR TITLE
controller: stop info logging of garbage collector runner

### DIFF
--- a/internal/controller/garbage_collector_runner.go
+++ b/internal/controller/garbage_collector_runner.go
@@ -45,13 +45,9 @@ func (r *GarbageCollectorRunner) Start(ctx context.Context) error {
 			break
 		}
 
-		logger.Info("garbage collection started")
-
 		if err := r.deleteOrphanedPVs(ctx); err != nil {
 			logger.Error(err, "failed to delete orphaned PVs", "error", err)
 		}
-
-		logger.Info("garbage collection finished")
 	}
 
 	return nil


### PR DESCRIPTION
Currently GarbageCollectorRunner prints info logs before and after the collection runs ("garbage collection started" and "garbage collection finished"). However, they are printed too frequently, especially in the e2e tests, and convey almost no information.

This commit removes this logging.