### PR TITLE
test: controller: wait restoring PVC creation before its deletion

### DIFF
--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -315,6 +315,11 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPVC() {
 		err := test.reconciler.createOrUpdateRestoringPVC(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
+		Eventually(ctx, func(g Gomega) {
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: restore.Name, Namespace: test.tenantNamespace}, &pvc)
+			g.Expect(err).NotTo(HaveOccurred())
+		}).Should(Succeed())
+
 		err = test.reconciler.deleteRestoringPVC(ctx, restore)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
The current implementation of `testDeleteResotringPVC` is unstable and it often fails with the following error message:

```
  [FAILED] Timed out after 180.001s.
  The function passed to Eventually failed at /home/rbanno/mantle/internal/controller/mantlerestore_controller_test.go:330 with:
  Expected an error to have occurred.  Got:
      <nil>: nil
  In [It] at: /home/rbanno/mantle/internal/controller/mantlerestore_controller_test.go:332 @ 12/10/25 06:11:00.185
```

It is probably because `test.reconciler.deleteRestoringPVC` is called before the restoring PVC is actually created. To resolve this problem this commit inserts code to wait for the PVC to be created before its deletion.

This commit is similar to the commit a6c380c. It was aimed for PVs, but this commit is for PVCs.