### PR TITLE
dockerignore: add test/e2e/bin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
 bin/
+
+# A workaround for "checking context: no permission to read from
+# '/home/user/mantle/test/e2e/bin/.minikube/machines/profile2/boot2docker.iso'" error.
+test/e2e/bin


### PR DESCRIPTION
In some environments (including mine), `make -C test/e2e test-multiple-k8s-clusters` fails to start minikube with the following error:

        checking context: no permission to read from '/home/user/mantle/test/e2e/bin/.minikube/machines/profile2/boot2docker.iso'

Adding `test/e2e/bin` to `.dockerignore` somehow fixes this error. We don't know why, but this line won't do harm, so let's add it.