### PR TITLE
mbcc kaizen: 2/n: implement finalizer for new MBC controller

### DIFF
--- a/.golangci-new.yml
+++ b/.golangci-new.yml
@@ -4,6 +4,14 @@ linters:
   disable:
     - depguard
     - wsl
+    - godox # Since we adopt the strangler-fig pattern, FIXME comments are inevitable.
+  settings:
+    exhaustruct:
+      exclude:
+        # The following packages are not designed to conform to this rule.
+        - k8s.io/.*
+        - sigs.k8s.io/controller-runtime/.*
+        - github.com/cybozu-go/mantle/api/.*
 formatters:
   enable:
     - gofmt

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.9
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
-	github.com/go-openapi/testify/v2 v2.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/pseudomuto/protoc-gen-doc v1.5.1
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.79.3

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
-github.com/go-openapi/testify/v2 v2.3.0 h1:cZFOKhatfyVejoFNd8jqnHFosegN5vJZiPOTnkyT9hA=
-github.com/go-openapi/testify/v2 v2.3.0/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=

--- a/internal/controller/domain/mbc_primary_reconciler.go
+++ b/internal/controller/domain/mbc_primary_reconciler.go
@@ -3,13 +3,54 @@
 // for MantleBackupConfig and related resources.
 package domain
 
+import (
+	"errors"
+
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
+	"github.com/cybozu-go/mantle/internal/controller/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	batchv1 "k8s.io/api/batch/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// MantleBackupConfig related constants.
+const (
+	// MantleBackupConfigFinalizerName is the finalizer name for MantleBackupConfig resources.
+	MantleBackupConfigFinalizerName = "mantlebackupconfig.mantle.cybozu.io/finalizer"
+	// MantleBackupConfigAnnotationManagedClusterID is the annotation key for the managed cluster ID.
+	MantleBackupConfigAnnotationManagedClusterID = "mantlebackupconfig.mantle.cybozu.io/managed-cluster-id"
+	// MantleBackupConfigCronJobNamePrefix is the prefix for CronJob names created for MantleBackupConfig.
+	MantleBackupConfigCronJobNamePrefix = "mbc-"
+)
+
+// ErrNotImplemented is returned when a functionality is not implemented yet.
+var ErrNotImplemented = errors.New("not implemented")
+
+// DeleteMBCCronJobOperation represents an operation to delete a CronJob associated with a MantleBackupConfig.
+type DeleteMBCCronJobOperation struct {
+	CronJob *batchv1.CronJob
+}
+
+func (*DeleteMBCCronJobOperation) isOperation() {}
+
+// GetMBCCronJobName returns the CronJob name for the given MantleBackupConfig.
+func GetMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {
+	return MantleBackupConfigCronJobNamePrefix + string(mbc.UID)
+}
+
 // MBCPrimaryReconciler is a reconciler for MantleBackupConfig resources
 // running on the primary cluster.
-type MBCPrimaryReconciler struct{}
+type MBCPrimaryReconciler struct {
+	managedCephClusterID string
+	Operations           *ReconcilerOperations
+}
 
 // NewMBCPrimaryReconciler creates a new MBCPrimaryReconciler instance.
-func NewMBCPrimaryReconciler() *MBCPrimaryReconciler {
-	return &MBCPrimaryReconciler{}
+func NewMBCPrimaryReconciler(managedCephClusterID string) *MBCPrimaryReconciler {
+	return &MBCPrimaryReconciler{
+		managedCephClusterID: managedCephClusterID,
+		Operations:           NewReconcilerOperations(),
+	}
 }
 
 // Provision handles the provisioning logic for MantleBackupConfig resources.
@@ -26,7 +67,7 @@ func NewMBCPrimaryReconciler() *MBCPrimaryReconciler {
 // processN() should do the actual work and make conditionN false eventually.
 // Comments should be left where this rule is not followed to explain why.
 func (r *MBCPrimaryReconciler) Provision() error {
-	return nil
+	return ErrNotImplemented
 }
 
 // Finalize handles the finalization logic for MantleBackupConfig resources.
@@ -42,6 +83,40 @@ func (r *MBCPrimaryReconciler) Provision() error {
 //
 // processN() should do the actual work and make conditionN false eventually.
 // Comments should be left where this rule is not followed to explain why.
-func (r *MBCPrimaryReconciler) Finalize() error {
+func (r *MBCPrimaryReconciler) Finalize(mbc *mantlev1.MantleBackupConfig, cronJob *batchv1.CronJob) error {
+	if !r.hasManagedCephClusterIDAnnotation(mbc) {
+		// We don't have to finalize this MBC.
+		return nil
+	}
+
+	_ = metrics.BackupConfigInfo.Delete(prometheus.Labels{
+		"persistentvolumeclaim": mbc.Spec.PVC,
+		"resource_namespace":    mbc.Namespace,
+		"mantlebackupconfig":    mbc.Name,
+	})
+
+	if cronJob != nil {
+		// Delete the CronJob first and return. The finalizer will be removed
+		// in the next reconcile cycle after the CronJob deletion is confirmed
+		// (i.e., cronJob becomes nil).
+		return r.deleteCronJob(cronJob)
+	}
+
+	return r.removeFinalizer(mbc)
+}
+
+func (r *MBCPrimaryReconciler) hasManagedCephClusterIDAnnotation(mbc *mantlev1.MantleBackupConfig) bool {
+	return mbc.Annotations[MantleBackupConfigAnnotationManagedClusterID] == r.managedCephClusterID
+}
+
+func (r *MBCPrimaryReconciler) deleteCronJob(cronJob *batchv1.CronJob) error {
+	r.Operations.Append(&DeleteMBCCronJobOperation{CronJob: cronJob})
+
+	return nil
+}
+
+func (r *MBCPrimaryReconciler) removeFinalizer(mbc *mantlev1.MantleBackupConfig) error {
+	controllerutil.RemoveFinalizer(mbc, MantleBackupConfigFinalizerName)
+
 	return nil
 }

--- a/internal/controller/domain/mbc_primary_reconciler_test.go
+++ b/internal/controller/domain/mbc_primary_reconciler_test.go
@@ -3,36 +3,176 @@ package domain_test
 import (
 	"testing"
 
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller/domain"
-	"github.com/go-openapi/testify/v2/require"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func newReconciler() *domain.MBCPrimaryReconciler {
-	return domain.NewMBCPrimaryReconciler()
+type optionMBC func(*mantlev1.MantleBackupConfig)
+
+func mbcWithAnnotAndFinalizer(sc *storagev1.StorageClass) optionMBC {
+	return func(mbc *mantlev1.MantleBackupConfig) {
+		mbc.Finalizers = append(mbc.Finalizers, domain.MantleBackupConfigFinalizerName)
+		mbc.Annotations[domain.MantleBackupConfigAnnotationManagedClusterID] = sc.Parameters["clusterID"]
+	}
 }
 
-func TestProvision_Success(t *testing.T) {
+func newMBC(opts ...optionMBC) *mantlev1.MantleBackupConfig {
+	mbc := &mantlev1.MantleBackupConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mbc-name",
+			Namespace:   "mbc-namespace",
+			UID:         "mbc-uid",
+			Annotations: map[string]string{},
+		},
+		Spec: mantlev1.MantleBackupConfigSpec{
+			PVC:      "pvc-name",
+			Schedule: "0 0 * * *",
+			Expire:   "2w",
+			Suspend:  false,
+		},
+	}
+	for _, opt := range opts {
+		opt(mbc)
+	}
+
+	return mbc
+}
+
+type optionSC func(*storagev1.StorageClass)
+
+func scWithClusterID(clusterID string) optionSC {
+	return func(sc *storagev1.StorageClass) {
+		sc.Parameters["clusterID"] = clusterID
+	}
+}
+
+func newSC(opts ...optionSC) *storagev1.StorageClass {
+	storageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sc-name",
+		},
+		Provisioner: "hoge.rbd.csi.ceph.com",
+		Parameters: map[string]string{
+			"clusterID": "ceph-cluster-id",
+		},
+	}
+	for _, opt := range opts {
+		opt(storageClass)
+	}
+
+	return storageClass
+}
+
+func newReconciler(sc *storagev1.StorageClass) *domain.MBCPrimaryReconciler {
+	return domain.NewMBCPrimaryReconciler(sc.Parameters["clusterID"])
+}
+
+func TestProvision_Error_NotImplemented(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	r := newReconciler()
+	r := newReconciler(newSC())
 
 	// Act
 	err := r.Provision()
 
 	// Assert
-	require.NoError(t, err)
+	require.ErrorIs(t, err, domain.ErrNotImplemented)
 }
 
-func TestFinalize_Success(t *testing.T) {
+// TestMBCPrimaryReconciler_Finalize_NoProvision tests that Finalize does
+// nothing when the MBC was never provisioned (i.e., has no finalizer).
+func TestMBCPrimaryReconciler_Finalize_NoProvision(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	r := newReconciler()
+	mbc := newMBC()
+	origMBC := mbc.DeepCopy()
+	reconciler := newReconciler(newSC())
 
 	// Act
-	err := r.Finalize()
+	err := reconciler.Finalize(mbc, nil)
 
 	// Assert
 	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+// TestMBCPrimaryReconciler_Finalize_RemoveCronJob tests that Finalize
+// emits a DeleteMBCCronJobOperation when the CronJob still exists.
+// The finalizer should not be removed until the CronJob is deleted.
+func TestMBCPrimaryReconciler_Finalize_RemoveCronJob(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	sc := newSC()
+	mbc := newMBC(mbcWithAnnotAndFinalizer(sc))
+	origMBC := mbc.DeepCopy()
+	reconciler := newReconciler(sc)
+	cronJob := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      domain.GetMBCCronJobName(mbc),
+			Namespace: "cronjob-namespace",
+		},
+	}
+
+	// Act
+	err := reconciler.Finalize(mbc, cronJob)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+
+	ops := reconciler.Operations.TakeAll()
+	require.Len(t, ops, 1)
+	op, ok := ops[0].(*domain.DeleteMBCCronJobOperation)
+	require.True(t, ok)
+	require.Equal(t, cronJob, op.CronJob)
+}
+
+// TestMBCPrimaryReconciler_Finalize_RemoveFinalizer tests that Finalize
+// removes the finalizer when the CronJob has already been deleted
+// (i.e., when cronJob is nil).
+func TestMBCPrimaryReconciler_Finalize_RemoveFinalizer(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	sc := newSC()
+	mbc := newMBC(mbcWithAnnotAndFinalizer(sc))
+	reconciler := newReconciler(sc)
+
+	// Act
+	err := reconciler.Finalize(mbc, nil)
+
+	// Assert
+	require.NoError(t, err)
+	require.Empty(t, mbc.Finalizers)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+// TestMBCPrimaryReconciler_Finalize_NotResponsibleStorageClass tests that
+// Finalize does nothing when the MBC was provisioned by a different reconciler
+// (identified by the managed cluster ID annotation).
+func TestMBCPrimaryReconciler_Finalize_NotResponsibleStorageClass(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	sc1 := newSC(scWithClusterID("ceph-cluster-id"))
+	sc2 := newSC(scWithClusterID("different-ceph-cluster-id"))
+	reconciler := newReconciler(sc1)
+	mbc := newMBC(mbcWithAnnotAndFinalizer(sc2))
+	origMBC := mbc.DeepCopy()
+
+	// Act
+	err := reconciler.Finalize(mbc, nil)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+	require.Empty(t, reconciler.Operations.TakeAll())
 }

--- a/internal/controller/domain/reconciler_operations.go
+++ b/internal/controller/domain/reconciler_operations.go
@@ -1,0 +1,33 @@
+package domain
+
+// Operation represents a single reconciler operation to be executed.
+// All concrete operation types must implement this interface by embedding
+// the unexported marker method to prevent external types from being used.
+type Operation interface {
+	isOperation()
+}
+
+// ReconcilerOperations is a collection of operations produced by a reconciler.
+type ReconcilerOperations struct {
+	operations []Operation
+}
+
+// NewReconcilerOperations creates a new empty ReconcilerOperations instance.
+func NewReconcilerOperations() *ReconcilerOperations {
+	return &ReconcilerOperations{
+		operations: []Operation{},
+	}
+}
+
+// Append adds an operation to the collection.
+func (e *ReconcilerOperations) Append(operation Operation) {
+	e.operations = append(e.operations, operation)
+}
+
+// TakeAll returns all operations and clears the internal collection.
+func (e *ReconcilerOperations) TakeAll() []Operation {
+	operations := e.operations
+	e.operations = []Operation{}
+
+	return operations
+}

--- a/internal/controller/infra/kubernetes_client.go
+++ b/internal/controller/infra/kubernetes_client.go
@@ -1,0 +1,55 @@
+package infra
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cybozu-go/mantle/internal/controller/domain"
+	"github.com/cybozu-go/mantle/internal/controller/usecase"
+	aerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type KubernetesClient struct {
+	client.Client
+}
+
+var _ usecase.KubernetesClient = (*KubernetesClient)(nil)
+
+func NewKubernetesClient(c client.Client) *KubernetesClient {
+	return &KubernetesClient{c}
+}
+
+func (c *KubernetesClient) ApplyReconcilerOperations(ctx context.Context, operations []domain.Operation) error {
+	logger := log.FromContext(ctx)
+	var dispatchError error
+
+	for _, i := range operations {
+		var err error
+
+		switch operation := i.(type) {
+		case *domain.DeleteMBCCronJobOperation:
+			logger.Info("deleting CronJob for MBC",
+				"name", operation.CronJob.Name, "namespace", operation.CronJob.Namespace)
+			err = c.Delete(ctx, operation.CronJob, &client.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             &operation.CronJob.UID,
+					ResourceVersion: &operation.CronJob.ResourceVersion,
+				},
+			})
+			if aerrors.IsNotFound(err) {
+				err = nil
+			}
+
+		default:
+			err = fmt.Errorf("unknown operation type: %T", i)
+		}
+
+		dispatchError = errors.Join(dispatchError, err)
+	}
+
+	return dispatchError
+}

--- a/internal/controller/mantlebackupconfig_controller.go
+++ b/internal/controller/mantlebackupconfig_controller.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	aerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
@@ -20,12 +21,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
+	"github.com/cybozu-go/mantle/internal/controller/domain"
+	"github.com/cybozu-go/mantle/internal/controller/infra"
 	"github.com/cybozu-go/mantle/internal/controller/metrics"
 	"github.com/cybozu-go/mantle/internal/controller/usecase"
 	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -42,6 +44,14 @@ type MantleBackupConfigReconciler struct {
 	overwriteMBCSchedule string
 	role                 string
 	uc                   *usecase.ReconcileMBCPrimary
+
+	// ucOnce guards the lazy initialization of uc. We cannot initialize uc in
+	// the constructor because it depends on cronJobInfo, which requires a
+	// running API server to resolve. Since Reconcile can be called concurrently
+	// by controller-runtime, sync.Once is used to ensure thread-safe one-time
+	// initialization.
+	// cf. https://github.com/kubernetes-sigs/controller-runtime/issues/616
+	ucOnce sync.Once
 }
 
 func NewMantleBackupConfigReconciler(
@@ -57,7 +67,7 @@ func NewMantleBackupConfigReconciler(
 		role:                 role,
 		managedCephClusterID: managedCephClusterID,
 		overwriteMBCSchedule: overwriteMBCSchedule,
-		uc:                   usecase.NewReconcileMBCPrimary(),
+		uc:                   nil,
 	}
 }
 
@@ -83,14 +93,23 @@ func (r *MantleBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.uc.Run(); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to run usecase: %w", err)
-	}
-
 	// Get the CronJob info to be created or updated
 	cronJobInfo, err := getCronJobInfo(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("couldn't get cronjob info: %w", err)
+	}
+
+	// TODO: We can't initialize r.uc in NewMantleBackupConfigReconciler due to
+	// the testing architecture. See https://github.com/cybozu-go/mantle/pull/252#discussion_r3063499989
+	// for details. We should refactor the code as soon as the old tests are removed.
+	r.ucOnce.Do(func() {
+		r.uc = usecase.NewReconcileMBCPrimary(r.managedCephClusterID, infra.NewKubernetesClient(r.Client), cronJobInfo.namespace)
+	})
+
+	if err := r.uc.Run(ctx, req.NamespacedName); err == nil {
+		return ctrl.Result{}, nil
+	} else if !errors.Is(err, domain.ErrNotImplemented) {
+		return ctrl.Result{}, fmt.Errorf("failed to run usecase: %w", err)
 	}
 
 	// Get MantleBackupConfig.
@@ -103,31 +122,6 @@ func (r *MantleBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		return ctrl.Result{}, fmt.Errorf("failed to get MantleBackupConfig: %w", err)
-	}
-
-	// When the deletionTimestamp is set, remove the finalizer and finish reconciling.
-	if !mbc.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(&mbc, MantleBackupConfigFinalizerName) &&
-			mbc.Annotations[MantleBackupConfigAnnotationManagedClusterID] == r.managedCephClusterID {
-			_ = metrics.BackupConfigInfo.Delete(prometheus.Labels{
-				"persistentvolumeclaim": mbc.Spec.PVC,
-				"resource_namespace":    mbc.Namespace,
-				"mantlebackupconfig":    mbc.Name,
-			})
-
-			// Delete the CronJob. If we failed to delete it because it's not found, ignore the error.
-			logger.Info("start deleting cronjobs")
-			if err := r.deleteCronJob(ctx, &mbc, cronJobInfo.namespace); err != nil && !aerrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to delete cronjob: %w", err)
-			}
-
-			controllerutil.RemoveFinalizer(&mbc, MantleBackupConfigFinalizerName)
-			if err := r.Client.Update(ctx, &mbc); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to remove mbc finalizer: %w", err)
-			}
-		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// Check if we're in charge of the given mbc.
@@ -306,31 +300,6 @@ func (r *MantleBackupConfigReconciler) createOrUpdateCronJob(ctx context.Context
 	}
 
 	return nil
-}
-
-func (r *MantleBackupConfigReconciler) deleteCronJob(ctx context.Context, mbc *mantlev1.MantleBackupConfig, namespace string) error {
-	var cronJob batchv1.CronJob
-	if err := r.Client.Get(
-		ctx,
-		types.NamespacedName{Name: getMBCCronJobName(mbc), Namespace: namespace},
-		&cronJob,
-	); err != nil {
-		return err
-	}
-
-	uid := cronJob.GetUID()
-	resourceVersion := cronJob.GetResourceVersion()
-
-	return r.Client.Delete(
-		ctx,
-		&cronJob,
-		&client.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID:             &uid,
-				ResourceVersion: &resourceVersion,
-			},
-		},
-	)
 }
 
 func getMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {

--- a/internal/controller/usecase/reconcile_common.go
+++ b/internal/controller/usecase/reconcile_common.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cybozu-go/mantle/internal/controller/domain"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// KubernetesClient is an interface for Kubernetes client operations used by reconcilers.
+type KubernetesClient interface {
+	client.Client
+	ApplyReconcilerOperations(ctx context.Context, operations []domain.Operation) error
+}
+
+func getResource[
+	T any,
+	PT interface {
+		*T
+		client.Object
+	},
+](ctx context.Context, k8sClient client.Client, name string, namespace string) (*T, error) {
+	obj := new(T)
+
+	err := k8sClient.Get(ctx, types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, PT(obj))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get %T %s/%s: %w", obj, namespace, name, err)
+	}
+
+	return obj, nil
+}

--- a/internal/controller/usecase/reconcile_mbc_primary.go
+++ b/internal/controller/usecase/reconcile_mbc_primary.go
@@ -4,22 +4,35 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
 
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller/domain"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	aerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ReconcileMBCPrimary is a use case that handles the reconciliation of
 // MantleBackupConfig resources on the primary cluster.
 type ReconcileMBCPrimary struct {
-	reconciler *domain.MBCPrimaryReconciler
+	reconciler       *domain.MBCPrimaryReconciler
+	k8sClient        KubernetesClient
+	cronJobNamespace string
 }
 
 // NewReconcileMBCPrimary creates a new ReconcileMBCPrimary instance.
-func NewReconcileMBCPrimary() *ReconcileMBCPrimary {
+func NewReconcileMBCPrimary(
+	managedCephClusterID string,
+	k8sClient KubernetesClient,
+	cronJobNamespace string,
+) *ReconcileMBCPrimary {
 	return &ReconcileMBCPrimary{
-		reconciler: domain.NewMBCPrimaryReconciler(),
+		reconciler:       domain.NewMBCPrimaryReconciler(managedCephClusterID),
+		k8sClient:        k8sClient,
+		cronJobNamespace: cronJobNamespace,
 	}
 }
 
@@ -29,13 +42,27 @@ func NewReconcileMBCPrimary() *ReconcileMBCPrimary {
 // 1. Fetch MantleBackupConfig and other related resources.
 // 2. Run Provision or Finalize based on the deletion timestamp of MantleBackupConfig.
 // 3. Update the status of MantleBackupConfig and related resources accordingly.
-func (r *ReconcileMBCPrimary) Run() error {
-	var mbc mantlev1.MantleBackupConfig
+func (r *ReconcileMBCPrimary) Run(ctx context.Context, mbcNamespacedName types.NamespacedName) error {
+	mbc, err := getResource[mantlev1.MantleBackupConfig](
+		ctx, r.k8sClient, mbcNamespacedName.Name, mbcNamespacedName.Namespace)
+	if err != nil {
+		if aerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	cronJob, err := getResource[batchv1.CronJob](ctx, r.k8sClient, domain.GetMBCCronJobName(mbc), r.cronJobNamespace)
+	if err != nil && !aerrors.IsNotFound(err) {
+		return err
+	}
+
 	if mbc.DeletionTimestamp.IsZero() {
 		return r.runProvision()
 	}
 
-	return r.runFinalize()
+	return r.runFinalize(ctx, mbc, cronJob)
 }
 
 func (r *ReconcileMBCPrimary) runProvision() error {
@@ -47,10 +74,33 @@ func (r *ReconcileMBCPrimary) runProvision() error {
 	return nil
 }
 
-func (r *ReconcileMBCPrimary) runFinalize() error {
-	err := r.reconciler.Finalize()
+func (r *ReconcileMBCPrimary) runFinalize(
+	ctx context.Context,
+	mbc *mantlev1.MantleBackupConfig,
+	cronJob *batchv1.CronJob,
+) error {
+	// Run finalize logic
+	origMBC := mbc.DeepCopy()
+	// Discard any leftover operations from a previous reconcile cycle that
+	// may have failed partway through, ensuring a clean slate.
+	_ = r.reconciler.Operations.TakeAll()
+
+	err := r.reconciler.Finalize(mbc, cronJob)
 	if err != nil {
 		return fmt.Errorf("finalize failed: %w", err)
+	}
+
+	// Persist changes
+	if !equality.Semantic.DeepEqual(origMBC, mbc) {
+		err := r.k8sClient.Update(ctx, mbc)
+		if err != nil {
+			return fmt.Errorf("failed to update MBC %s/%s: %w", mbc.GetNamespace(), mbc.GetName(), err)
+		}
+	}
+
+	err = r.k8sClient.ApplyReconcilerOperations(ctx, r.reconciler.Operations.TakeAll())
+	if err != nil {
+		return fmt.Errorf("failed to apply reconciler operations: %w", err)
 	}
 
 	return nil

--- a/internal/controller/usecase/reconcile_mbc_primary_test.go
+++ b/internal/controller/usecase/reconcile_mbc_primary_test.go
@@ -1,25 +1,190 @@
 package usecase_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	mantlev1 "github.com/cybozu-go/mantle/api/v1"
+	"github.com/cybozu-go/mantle/internal/controller/domain"
+	"github.com/cybozu-go/mantle/internal/controller/infra"
 	"github.com/cybozu-go/mantle/internal/controller/usecase"
-	"github.com/go-openapi/testify/v2/require"
+	"github.com/cybozu-go/mantle/test/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	aerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-func newUsecase() *usecase.ReconcileMBCPrimary {
-	return usecase.NewReconcileMBCPrimary()
+var k8sClient client.Client //nolint:gochecknoglobals
+
+func TestMain(m *testing.M) {
+	kubernetesVersion := os.Getenv("ENVTEST_KUBERNETES_VERSION")
+	if kubernetesVersion == "" {
+		kubernetesVersion = "1.34.0" // Set default value to make VSCode's Go extension work.
+	}
+
+	binaryAssetsDirectory := os.Getenv("ENVTEST_BIN_DIR")
+	if binaryAssetsDirectory == "" {
+		binaryAssetsDirectory = "../../../bin" // Set default value to make VSCode's Go extension work.
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:           []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:       true,
+		DownloadBinaryAssets:        true,
+		DownloadBinaryAssetsVersion: "v" + kubernetesVersion,
+		BinaryAssetsDirectory:       binaryAssetsDirectory,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	if cfg == nil {
+		panic("cfg is nil")
+	}
+
+	defer func() {
+		err := testEnv.Stop()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	err = mantlev1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		panic(err)
+	}
+
+	m.Run()
 }
 
-func TestRun_ProvisionPath_Success(t *testing.T) {
+func newUsecase(cephClusterID, cronJobNamespace string) *usecase.ReconcileMBCPrimary {
+	return usecase.NewReconcileMBCPrimary(cephClusterID, infra.NewKubernetesClient(k8sClient), cronJobNamespace)
+}
+
+//nolint:funlen // After we implement the provision logic, the length will be reduced.
+func TestRun_FinalizePath_Success(t *testing.T) {
 	t.Parallel()
 
-	// Arrange
-	r := newUsecase()
+	mbcName := util.GetUniqueName("mbc-")
+	mbcNamespace := util.GetUniqueName("ns-")
+	cronJobNamespace := util.GetUniqueName("ns-")
+	cephClusterID := util.GetUniqueName("managed-ceph-cluster-id")
 
-	// Act
-	err := r.Run()
+	// Create namespaces
+	for _, ns := range []string{mbcNamespace, cronJobNamespace} {
+		err := k8sClient.Create(t.Context(), &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: ns},
+		})
+		require.NoError(t, err)
+	}
 
-	// Assert
+	// Create MBC
+	mbc := &mantlev1.MantleBackupConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mbcName,
+			Namespace: mbcNamespace,
+			// FIXME: After we implement the provision logic, we should not set
+			// the finalizer and annotation manually in this test.
+			Finalizers: []string{
+				domain.MantleBackupConfigFinalizerName,
+			},
+			Annotations: map[string]string{
+				domain.MantleBackupConfigAnnotationManagedClusterID: cephClusterID,
+			},
+		},
+		Spec: mantlev1.MantleBackupConfigSpec{
+			PVC:      "pvc-name",
+			Schedule: "0 0 * * *",
+			Expire:   "2w",
+			Suspend:  false,
+		},
+	}
+	err := k8sClient.Create(t.Context(), mbc)
 	require.NoError(t, err)
+
+	// Create CronJob
+	// FIXME: After we implement the provision logic, we should not create the CronJob manually in this test.
+	err = k8sClient.Create(t.Context(), &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      domain.GetMBCCronJobName(mbc),
+			Namespace: cronJobNamespace,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 0 * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "backup",
+								Image: "backup-image",
+							}},
+							RestartPolicy: corev1.RestartPolicyOnFailure,
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Delete MBC to trigger the finalization logic
+	err = k8sClient.Delete(t.Context(), mbc)
+	require.NoError(t, err)
+
+	// Run the usecase
+	useCase := newUsecase(cephClusterID, cronJobNamespace)
+	err = useCase.Run(
+		t.Context(),
+		types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
+	)
+	require.NoError(t, err)
+
+	// Verify that the CronJob is deleted
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err = k8sClient.Get(
+			t.Context(),
+			types.NamespacedName{Name: domain.GetMBCCronJobName(mbc), Namespace: cronJobNamespace},
+			&batchv1.CronJob{},
+		)
+		assert.Error(collect, err)
+		assert.True(collect, aerrors.IsNotFound(err))
+	}, 5*time.Second, 1*time.Second)
+
+	// Run the usecase a second time to verify that the finalizer is removed.
+	// The first Run deletes the CronJob; the second Run should remove the finalizer.
+	err = useCase.Run(
+		t.Context(),
+		types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
+	)
+	require.NoError(t, err)
+
+	// Verify that the MBC has been garbage-collected by the API server.
+	// Once the finalizer is removed from a resource with DeletionTimestamp,
+	// Kubernetes deletes it automatically.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		err = k8sClient.Get(
+			t.Context(),
+			types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
+			&mantlev1.MantleBackupConfig{},
+		)
+		assert.Error(collect, err)
+		assert.True(collect, aerrors.IsNotFound(err))
+	}, 5*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
This commit implements finalization process of MBC resources in the new
architecture, i.e., by using domains and usecases.

- 1/n: https://github.com/cybozu-go/mantle/pull/250