### PR TITLE
e2e: show kubectl stderr on failure in EnsureCorrectRestoration

### DIFF
--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -625,9 +625,9 @@ func EnsureCorrectRestoration(
 	Eventually(ctx, func(g Gomega) {
 		err := ApplyMountDeployTemplate(clusterNo, namespace, mountDeployName, restoreName)
 		g.Expect(err).NotTo(HaveOccurred())
-		stdout, _, err := Kubectl(clusterNo, nil, "exec", "-n", namespace, "deploy/"+mountDeployName, "--",
+		stdout, stderr, err := Kubectl(clusterNo, nil, "exec", "-n", namespace, "deploy/"+mountDeployName, "--",
 			"bash", "-c", "sha256sum /volume/data | awk '{print $1}'")
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(err).NotTo(HaveOccurred(), "stderr: %s", string(stderr))
 		g.Expect(string(stdout)).To(Equal(writtenDataHash))
 	}).Should(Succeed())
 }


### PR DESCRIPTION
In the "checking the MantleRestore has the correct contents" step, stderr from `kubectl exec` was silently discarded, making it impossible to diagnose failures. Pass it as a Gomega annotation so it appears in the failure message automatically.
cmd.Output() was not used to keep the change minimal.