### PR TITLE
controller: add --max-import-jobs to throttle concurrent import jobs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -55,6 +55,7 @@ var (
 	role                         string
 	mantleServiceEndpoint        string
 	maxExportJobs                int
+	maxImportJobs                int
 	maxUploadJobs                int
 	exportDataStorageClass       string
 	envSecret                    string
@@ -99,6 +100,8 @@ func init() {
 			"this option is required and is interpreted as the address that the secondary mantle should listen to.")
 	flags.IntVar(&maxExportJobs, "max-export-jobs", 8,
 		"The maximum number of export jobs that can run simultaneously. If you set this to 0, there is no limit.")
+	flags.IntVar(&maxImportJobs, "max-import-jobs", 8,
+		"The maximum number of import jobs that can run simultaneously. If you set this to 0, there is no limit.")
 	flags.IntVar(&maxUploadJobs, "max-upload-jobs", 8,
 		"The maximum number of export jobs that can run simultaneously. If you set this to 0, there is no limit.")
 	flags.StringVar(&exportDataStorageClass, "export-data-storage-class", "",
@@ -233,7 +236,11 @@ func checkCommandlineArgs() error {
 	return nil
 }
 
-func setupReconcilers(mgr manager.Manager, primarySettings *controller.PrimarySettings) error {
+func setupReconcilers(
+	mgr manager.Manager,
+	primarySettings *controller.PrimarySettings,
+	secondarySettings *controller.SecondarySettings,
+) error {
 	managedCephClusterID := os.Getenv("POD_NAMESPACE")
 	if managedCephClusterID == "" {
 		setupLog.Error(errors.New("POD_NAMESPACE is empty"), "POD_NAMESPACE is empty")
@@ -279,6 +286,7 @@ func setupReconcilers(mgr manager.Manager, primarySettings *controller.PrimarySe
 		managedCephClusterID,
 		role,
 		primarySettings,
+		secondarySettings,
 		podImage,
 		envSecret,
 		&controller.ObjectStorageSettings{
@@ -348,7 +356,7 @@ func setupReconcilers(mgr manager.Manager, primarySettings *controller.PrimarySe
 }
 
 func setupStandalone(mgr manager.Manager) error {
-	return setupReconcilers(mgr, nil)
+	return setupReconcilers(mgr, nil, nil)
 }
 
 func setupPrimary(ctx context.Context, mgr manager.Manager, wg *sync.WaitGroup) error {
@@ -418,7 +426,7 @@ func setupPrimary(ctx context.Context, mgr manager.Manager, wg *sync.WaitGroup) 
 		ExportDataStorageClass: exportDataStorageClass,
 	}
 
-	return setupReconcilers(mgr, primarySettings)
+	return setupReconcilers(mgr, primarySettings, nil)
 }
 
 func setupSecondary(ctx context.Context, mgr manager.Manager, wg *sync.WaitGroup, cancel context.CancelFunc) error {
@@ -476,7 +484,9 @@ func setupSecondary(ctx context.Context, mgr manager.Manager, wg *sync.WaitGroup
 		serv.GracefulStop()
 	}()
 
-	return setupReconcilers(mgr, nil)
+	return setupReconcilers(mgr, nil, &controller.SecondarySettings{
+		MaxImportJobs: maxImportJobs,
+	})
 }
 
 func subMain() error {

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -117,7 +117,8 @@ type MantleBackupReconciler struct {
 	ceph                   ceph.CephCmd
 	managedCephClusterID   string
 	role                   string
-	primarySettings        *PrimarySettings // This should be non-nil if and only if role equals 'primary'.
+	primarySettings        *PrimarySettings   // This should be non-nil if and only if role equals 'primary'.
+	secondarySettings      *SecondarySettings // This should be non-nil if and only if role equals 'secondary'.
 	expireQueueCh          chan event.GenericEvent
 	podImage               string
 	envSecret              string
@@ -134,6 +135,7 @@ func NewMantleBackupReconciler(
 	managedCephClusterID,
 	role string,
 	primarySettings *PrimarySettings,
+	secondarySettings *SecondarySettings,
 	podImage string,
 	envSecret string,
 	objectStorageSettings *ObjectStorageSettings,
@@ -147,6 +149,7 @@ func NewMantleBackupReconciler(
 		managedCephClusterID:   managedCephClusterID,
 		role:                   role,
 		primarySettings:        primarySettings,
+		secondarySettings:      secondarySettings,
 		expireQueueCh:          make(chan event.GenericEvent),
 		podImage:               podImage,
 		envSecret:              envSecret,
@@ -1345,8 +1348,8 @@ func (r *MantleBackupReconciler) handleCompletedExportJobs(ctx context.Context, 
 	return r.handleCompletedJobsOfComponent(ctx, backup, labelComponentExportJob, MantleExportJobPrefix, nil)
 }
 
-func (r *MantleBackupReconciler) canNewExportJobBeCreated(ctx context.Context) (bool, error) {
-	if r.primarySettings.MaxExportJobs == 0 {
+func (r *MantleBackupReconciler) canNewJobBeCreated(ctx context.Context, maxJobs int, component string) (bool, error) {
+	if maxJobs == 0 {
 		return true, nil
 	}
 
@@ -1355,10 +1358,10 @@ func (r *MantleBackupReconciler) canNewExportJobBeCreated(ctx context.Context) (
 		Namespace: r.managedCephClusterID,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/name":      labelAppNameValue,
-			"app.kubernetes.io/component": labelComponentExportJob,
+			"app.kubernetes.io/component": component,
 		}),
 	}); err != nil {
-		return false, fmt.Errorf("failed to list export Jobs: %w", err)
+		return false, fmt.Errorf("failed to list %s Jobs: %w", component, err)
 	}
 
 	// exclude completed jobs
@@ -1369,11 +1372,19 @@ func (r *MantleBackupReconciler) canNewExportJobBeCreated(ctx context.Context) (
 		}
 	}
 
-	if count >= r.primarySettings.MaxExportJobs {
-		return false, nil
+	return count < maxJobs, nil
+}
+
+func (r *MantleBackupReconciler) canNewExportJobBeCreated(ctx context.Context) (bool, error) {
+	return r.canNewJobBeCreated(ctx, r.primarySettings.MaxExportJobs, labelComponentExportJob)
+}
+
+func (r *MantleBackupReconciler) canNewImportJobBeCreated(ctx context.Context) (bool, error) {
+	if r.secondarySettings == nil {
+		return true, nil
 	}
 
-	return true, nil
+	return r.canNewJobBeCreated(ctx, r.secondarySettings.MaxImportJobs, labelComponentImportJob)
 }
 
 func (r *MantleBackupReconciler) getPartNumRangeOfExpectedRunningUploadJobs(
@@ -2651,6 +2662,15 @@ func (r *MantleBackupReconciler) reconcileImportJob(
 	if !uploaded {
 		logger.Info("export data for the next part is not yet uploaded", "partNum", partNum)
 
+		return requeueReconciliation(), nil
+	}
+
+	// check if a new import Job can be created
+	ok, err := r.canNewImportJobBeCreated(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check if a new import Job can be created: %w", err)
+	}
+	if !ok {
 		return requeueReconciliation(), nil
 	}
 

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -200,6 +200,7 @@ var _ = Describe("MantleBackup controller", func() {
 				resMgr.ClusterID,
 				RoleStandalone,
 				nil,
+				nil,
 				"dummy image",
 				"",
 				nil,
@@ -455,6 +456,7 @@ var _ = Describe("MantleBackup controller", func() {
 					Client:                 grpcClient,
 					ExportDataStorageClass: resMgr.StorageClassName,
 				},
+				nil,
 				"dummy image",
 				"dummy-secret-env",
 				&ObjectStorageSettings{
@@ -979,7 +981,7 @@ var _ = Describe("prepareForDataSynchronization", func() {
 		}
 
 		mbr := NewMantleBackupReconciler(ctrlClient,
-			ctrlClient.Scheme(), "test", RolePrimary, nil, "dummy image", "", nil, nil, resource.MustParse("1Gi"))
+			ctrlClient.Scheme(), "test", RolePrimary, nil, nil, "dummy image", "", nil, nil, resource.MustParse("1Gi"))
 
 		ret, err := mbr.prepareForDataSynchronization(context.Background(),
 			backup, grpcClient)
@@ -1516,6 +1518,7 @@ var _ = Describe("export and upload", func() {
 				ExportDataStorageClass: resMgr.StorageClassName,
 				MaxExportJobs:          1,
 			},
+			nil,
 			"dummy image",
 			"dummy-secret",
 			&ObjectStorageSettings{},
@@ -1606,6 +1609,7 @@ var _ = Describe("export and upload", func() {
 					ExportDataStorageClass: resMgr.StorageClassName,
 					MaxExportJobs:          1,
 				},
+				nil,
 				"dummy image",
 				"",
 				nil,
@@ -1759,6 +1763,7 @@ var _ = Describe("import", func() {
 			nsController,
 			RoleSecondary,
 			nil,
+			nil,
 			"dummy-image",
 			"dummy-env-secret",
 			&ObjectStorageSettings{},
@@ -1776,6 +1781,32 @@ var _ = Describe("import", func() {
 			mockCtrl.Finish()
 		}
 	})
+
+	createAndReconcileImportJob := func(
+		ctx SpecContext,
+		mbr *MantleBackupReconciler,
+		name, ns string,
+	) {
+		GinkgoHelper()
+
+		target, err := createMantleBackupUsingDummyPVC(ctx, name, ns)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = updateStatus(ctx, k8sClient, target, func() error {
+			target.Status.SnapSize = ptr.To(int64(testutil.FakeRBDSnapshotSize))
+			transferPartSize := resource.MustParse("1Gi")
+			target.Status.TransferPartSize = &transferPartSize
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		snapshotTarget, err := getSnapshotTargetByDummyMB(target)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = mbr.reconcileImportJob(ctx, target, snapshotTarget, -1)
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	DescribeTable("isExportDataAlreadyUploaded: inputs and outputs",
 		func(ctx SpecContext, gotExist, gotError, expectUploaded, expectError bool) {
@@ -1855,6 +1886,88 @@ var _ = Describe("import", func() {
 			res, err = mbr.reconcileImportJob(ctx, backup, snapshotTarget, largestCompletedPartNum)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res.IsZero()).To(BeTrue())
+		})
+	})
+
+	Context("import job throttling", func() {
+		It("should throttle import jobs correctly", func(ctx SpecContext) {
+			nsController = resMgr.CreateNamespace()
+			mbr = NewMantleBackupReconciler(
+				k8sClient,
+				scheme.Scheme,
+				nsController,
+				RoleSecondary,
+				nil,
+				&SecondarySettings{
+					MaxImportJobs: 1,
+				},
+				"dummy-image",
+				"dummy-env-secret",
+				&ObjectStorageSettings{},
+				nil,
+				resource.MustParse("1Gi"),
+			)
+			mbr.objectStorageClient = mockObjectStorage
+			mbr.ceph = testutil.NewFakeRBD()
+
+			getNumOfImportJobs := func(ns string) (int, error) {
+				var jobs batchv1.JobList
+				err := k8sClient.List(ctx, &jobs, &client.ListOptions{
+					Namespace: ns,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"app.kubernetes.io/name":      labelAppNameValue,
+						"app.kubernetes.io/component": labelComponentImportJob,
+					}),
+				})
+
+				return len(jobs.Items), err
+			}
+
+			mockObjectStorage.EXPECT().Exists(gomock.Any(), gomock.Any()).
+				Return(true, nil).AnyTimes()
+
+			// create 5 different MantleBackup resources and call reconcileImportJob for each of them
+			for i := range 5 {
+				createAndReconcileImportJob(ctx, mbr, fmt.Sprintf("target1-%d", i), ns)
+			}
+
+			// make sure that only 1 Job is created
+			Consistently(ctx, func(g Gomega) error {
+				numJobs, err := getNumOfImportJobs(nsController)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numJobs).To(Equal(1))
+
+				return nil
+			}, "1s").Should(Succeed())
+
+			// make sure that another mantle-controller existing in a different namespace can create an import Job
+			nsController2 := resMgr.CreateNamespace()
+			mbr2 := NewMantleBackupReconciler(
+				k8sClient,
+				scheme.Scheme,
+				nsController2,
+				RoleSecondary,
+				nil,
+				&SecondarySettings{
+					MaxImportJobs: 1,
+				},
+				"dummy-image",
+				"dummy-env-secret",
+				&ObjectStorageSettings{},
+				nil,
+				resource.MustParse("1Gi"),
+			)
+			mbr2.objectStorageClient = mockObjectStorage
+			mbr2.ceph = testutil.NewFakeRBD()
+			ns2 := resMgr.CreateNamespace()
+			createAndReconcileImportJob(ctx, mbr2, "target2", ns2)
+			Eventually(ctx, func(g Gomega) error {
+				numJobs, err := getNumOfImportJobs(nsController2)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numJobs).To(Equal(1))
+
+				return nil
+			}).Should(Succeed())
 		})
 	})
 
@@ -2580,7 +2693,7 @@ var _ = Describe("MantleBackupReconciler", func() {
 		}
 
 		It("setup", func(ctx SpecContext) {
-			reconciler = NewMantleBackupReconciler(nil, nil, "", "", nil, "", "", nil, nil, resource.Quantity{})
+			reconciler = NewMantleBackupReconciler(nil, nil, "", "", nil, nil, "", "", nil, nil, resource.Quantity{})
 			cephCmd = testutil.NewFakeRBD()
 			reconciler.ceph = cephCmd
 		})
@@ -2617,7 +2730,7 @@ var _ = Describe("MantleBackupReconciler", func() {
 		var cephCmd *testutil.FakeRBD
 
 		It("setup", func(ctx SpecContext) {
-			reconciler = NewMantleBackupReconciler(nil, nil, "", "", nil, "", "", nil, nil, resource.Quantity{})
+			reconciler = NewMantleBackupReconciler(nil, nil, "", "", nil, nil, "", "", nil, nil, resource.Quantity{})
 			cephCmd = testutil.NewFakeRBD()
 			reconciler.ceph = cephCmd
 		})
@@ -2833,6 +2946,7 @@ set -eux -o pipefail
 				mgrUtil.GetManager().GetScheme(),
 				podNamespace,
 				"",  // unused
+				nil, // unused
 				nil, // unused
 				podImage,
 				"",                  // unused

--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -58,6 +58,7 @@ func (test *mantleRestoreControllerUnitTest) setupEnv() {
 			resMgr.ClusterID,
 			RoleStandalone,
 			nil,
+			nil,
 			"dummy image",
 			"",
 			nil,

--- a/internal/controller/replication.go
+++ b/internal/controller/replication.go
@@ -32,6 +32,10 @@ type PrimarySettings struct {
 	ExportDataStorageClass string
 }
 
+type SecondarySettings struct {
+	MaxImportJobs int
+}
+
 type SecondaryServer struct {
 	client client.Client
 	proto.UnimplementedMantleServiceServer


### PR DESCRIPTION
Among the jobs involved in primary-to-secondary replication, only export jobs currently have a limit on concurrency. This adds --max-import-jobs (default: 8) to also throttle concurrent import jobs.