### PR TITLE
refactor(controller): move MBC provision logic to domain/usecase/infra layers

### DIFF
--- a/internal/controller/domain/mbc_primary_reconciler.go
+++ b/internal/controller/domain/mbc_primary_reconciler.go
@@ -4,12 +4,13 @@
 package domain
 
 import (
-	"errors"
+	"strings"
 
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -23,15 +24,26 @@ const (
 	MantleBackupConfigCronJobNamePrefix = "mbc-"
 )
 
-// ErrNotImplemented is returned when a functionality is not implemented yet.
-var ErrNotImplemented = errors.New("not implemented")
-
 // DeleteMBCCronJobOperation represents an operation to delete a CronJob associated with a MantleBackupConfig.
 type DeleteMBCCronJobOperation struct {
 	CronJob *batchv1.CronJob
 }
 
 func (*DeleteMBCCronJobOperation) isOperation() {}
+
+// CreateOrUpdateMBCCronJobOperation represents an operation to create or update a CronJob for a MantleBackupConfig.
+type CreateOrUpdateMBCCronJobOperation struct {
+	CronJobName        string
+	CronJobNamespace   string
+	Schedule           string
+	Suspend            bool
+	ServiceAccountName string
+	Image              string
+	MBCName            string
+	MBCNamespace       string
+}
+
+func (*CreateOrUpdateMBCCronJobOperation) isOperation() {}
 
 // GetMBCCronJobName returns the CronJob name for the given MantleBackupConfig.
 func GetMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {
@@ -42,13 +54,27 @@ func GetMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {
 // running on the primary cluster.
 type MBCPrimaryReconciler struct {
 	managedCephClusterID string
+	overwriteMBCSchedule string
+	cronJobNamespace     string
+	serviceAccountName   string
+	image                string
 	Operations           *ReconcilerOperations
 }
 
 // NewMBCPrimaryReconciler creates a new MBCPrimaryReconciler instance.
-func NewMBCPrimaryReconciler(managedCephClusterID string) *MBCPrimaryReconciler {
+func NewMBCPrimaryReconciler(
+	managedCephClusterID string,
+	overwriteMBCSchedule string,
+	cronJobNamespace string,
+	serviceAccountName string,
+	image string,
+) *MBCPrimaryReconciler {
 	return &MBCPrimaryReconciler{
 		managedCephClusterID: managedCephClusterID,
+		overwriteMBCSchedule: overwriteMBCSchedule,
+		cronJobNamespace:     cronJobNamespace,
+		serviceAccountName:   serviceAccountName,
+		image:                image,
 		Operations:           NewReconcilerOperations(),
 	}
 }
@@ -66,8 +92,26 @@ func NewMBCPrimaryReconciler(managedCephClusterID string) *MBCPrimaryReconciler 
 //
 // processN() should do the actual work and make conditionN false eventually.
 // Comments should be left where this rule is not followed to explain why.
-func (r *MBCPrimaryReconciler) Provision() error {
-	return ErrNotImplemented
+func (r *MBCPrimaryReconciler) Provision(mbc *mantlev1.MantleBackupConfig, sc *storagev1.StorageClass) error {
+	if !r.isResponsibleToStorageClass(sc) {
+		return nil
+	}
+
+	if !controllerutil.ContainsFinalizer(mbc, MantleBackupConfigFinalizerName) {
+		r.addFinalizerAndAnnotation(mbc)
+
+		return nil
+	}
+
+	metrics.BackupConfigInfo.With(prometheus.Labels{
+		"persistentvolumeclaim": mbc.Spec.PVC,
+		"resource_namespace":    mbc.Namespace,
+		"mantlebackupconfig":    mbc.Name,
+	}).Set(1)
+
+	r.createOrUpdateCronJob(mbc)
+
+	return nil
 }
 
 // Finalize handles the finalization logic for MantleBackupConfig resources.
@@ -119,4 +163,43 @@ func (r *MBCPrimaryReconciler) removeFinalizer(mbc *mantlev1.MantleBackupConfig)
 	controllerutil.RemoveFinalizer(mbc, MantleBackupConfigFinalizerName)
 
 	return nil
+}
+
+func (r *MBCPrimaryReconciler) addFinalizerAndAnnotation(mbc *mantlev1.MantleBackupConfig) {
+	if mbc.Annotations == nil {
+		mbc.Annotations = make(map[string]string)
+	}
+
+	mbc.Annotations[MantleBackupConfigAnnotationManagedClusterID] = r.managedCephClusterID
+	controllerutil.AddFinalizer(mbc, MantleBackupConfigFinalizerName)
+}
+
+func (r *MBCPrimaryReconciler) isResponsibleToStorageClass(storageClass *storagev1.StorageClass) bool {
+	if storageClass == nil {
+		return false
+	}
+
+	if !strings.HasSuffix(storageClass.Provisioner, ".rbd.csi.ceph.com") {
+		return false
+	}
+
+	return storageClass.Parameters["clusterID"] == r.managedCephClusterID
+}
+
+func (r *MBCPrimaryReconciler) createOrUpdateCronJob(mbc *mantlev1.MantleBackupConfig) {
+	schedule := mbc.Spec.Schedule
+	if r.overwriteMBCSchedule != "" {
+		schedule = r.overwriteMBCSchedule
+	}
+
+	r.Operations.Append(&CreateOrUpdateMBCCronJobOperation{
+		CronJobName:        GetMBCCronJobName(mbc),
+		CronJobNamespace:   r.cronJobNamespace,
+		Schedule:           schedule,
+		Suspend:            mbc.Spec.Suspend,
+		ServiceAccountName: r.serviceAccountName,
+		Image:              r.image,
+		MBCName:            mbc.Name,
+		MBCNamespace:       mbc.Namespace,
+	})
 }

--- a/internal/controller/domain/mbc_primary_reconciler_test.go
+++ b/internal/controller/domain/mbc_primary_reconciler_test.go
@@ -67,21 +67,189 @@ func newSC(opts ...optionSC) *storagev1.StorageClass {
 	return storageClass
 }
 
-func newReconciler(sc *storagev1.StorageClass) *domain.MBCPrimaryReconciler {
-	return domain.NewMBCPrimaryReconciler(sc.Parameters["clusterID"])
+func newReconciler(storageClass *storagev1.StorageClass, opts ...func(*reconcilerConfig)) *domain.MBCPrimaryReconciler {
+	cfg := &reconcilerConfig{
+		overwriteMBCSchedule: "",
+		cronJobNamespace:     "",
+		serviceAccountName:   "",
+		image:                "",
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return domain.NewMBCPrimaryReconciler(
+		storageClass.Parameters["clusterID"],
+		cfg.overwriteMBCSchedule,
+		cfg.cronJobNamespace,
+		cfg.serviceAccountName,
+		cfg.image,
+	)
 }
 
-func TestProvision_Error_NotImplemented(t *testing.T) {
+type reconcilerConfig struct {
+	overwriteMBCSchedule string
+	cronJobNamespace     string
+	serviceAccountName   string
+	image                string
+}
+
+func withOverwriteSchedule(schedule string) func(*reconcilerConfig) {
+	return func(cfg *reconcilerConfig) {
+		cfg.overwriteMBCSchedule = schedule
+	}
+}
+
+func withCronJobNamespace(ns string) func(*reconcilerConfig) {
+	return func(cfg *reconcilerConfig) {
+		cfg.cronJobNamespace = ns
+	}
+}
+
+func withServiceAccountName(sa string) func(*reconcilerConfig) {
+	return func(cfg *reconcilerConfig) {
+		cfg.serviceAccountName = sa
+	}
+}
+
+func withImage(image string) func(*reconcilerConfig) {
+	return func(cfg *reconcilerConfig) {
+		cfg.image = image
+	}
+}
+
+func TestMBCPrimaryReconciler_Provision_NotResponsibleCluster(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	r := newReconciler(newSC())
+	sc := newSC(scWithClusterID("ceph-cluster-id"))
+	reconciler := newReconciler(sc)
+	mbc := newMBC()
+	origMBC := mbc.DeepCopy()
+	differentSC := newSC(scWithClusterID("different-ceph-cluster-id"))
 
 	// Act
-	err := r.Provision()
+	err := reconciler.Provision(mbc, differentSC)
 
 	// Assert
-	require.ErrorIs(t, err, domain.ErrNotImplemented)
+	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+func TestMBCPrimaryReconciler_Provision_NilStorageClass(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	sc := newSC()
+	reconciler := newReconciler(sc)
+	mbc := newMBC()
+	origMBC := mbc.DeepCopy()
+
+	// Act
+	err := reconciler.Provision(mbc, nil)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+func TestMBCPrimaryReconciler_Provision_NonCephProvisioner(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	sc := newSC()
+	reconciler := newReconciler(sc)
+	mbc := newMBC()
+	origMBC := mbc.DeepCopy()
+	nonCephSC := newSC()
+	nonCephSC.Provisioner = "kubernetes.io/no-provisioner"
+
+	// Act
+	err := reconciler.Provision(mbc, nonCephSC)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, origMBC, mbc)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+func TestMBCPrimaryReconciler_Provision_AddFinalizerAndAnnotation(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	storageClass := newSC()
+	reconciler := newReconciler(storageClass)
+	mbc := newMBC()
+
+	// Act
+	err := reconciler.Provision(mbc, storageClass)
+
+	// Assert
+	require.NoError(t, err)
+	require.Contains(t, mbc.Finalizers, domain.MantleBackupConfigFinalizerName)
+	require.Equal(t,
+		storageClass.Parameters["clusterID"],
+		mbc.Annotations[domain.MantleBackupConfigAnnotationManagedClusterID],
+	)
+	require.Empty(t, reconciler.Operations.TakeAll())
+}
+
+func TestMBCPrimaryReconciler_Provision_CreateOrUpdateCronJob(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	storageClass := newSC()
+	reconciler := newReconciler(storageClass,
+		withCronJobNamespace("cronjob-ns"),
+		withServiceAccountName("sa-name"),
+		withImage("controller-image"),
+	)
+	mbc := newMBC(mbcWithAnnotAndFinalizer(storageClass))
+
+	// Act
+	err := reconciler.Provision(mbc, storageClass)
+
+	// Assert
+	require.NoError(t, err)
+
+	ops := reconciler.Operations.TakeAll()
+	require.Len(t, ops, 1)
+
+	operation, ok := ops[0].(*domain.CreateOrUpdateMBCCronJobOperation)
+	require.True(t, ok)
+	require.Equal(t, domain.GetMBCCronJobName(mbc), operation.CronJobName)
+	require.Equal(t, "cronjob-ns", operation.CronJobNamespace)
+	require.Equal(t, mbc.Spec.Schedule, operation.Schedule)
+	require.Equal(t, mbc.Spec.Suspend, operation.Suspend)
+	require.Equal(t, "sa-name", operation.ServiceAccountName)
+	require.Equal(t, "controller-image", operation.Image)
+	require.Equal(t, mbc.Name, operation.MBCName)
+	require.Equal(t, mbc.Namespace, operation.MBCNamespace)
+}
+
+func TestMBCPrimaryReconciler_Provision_OverwriteSchedule(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	storageClass := newSC()
+	overwrittenSchedule := "*/5 * * * *"
+	reconciler := newReconciler(storageClass, withOverwriteSchedule(overwrittenSchedule))
+	mbc := newMBC(mbcWithAnnotAndFinalizer(storageClass))
+
+	// Act
+	err := reconciler.Provision(mbc, storageClass)
+
+	// Assert
+	require.NoError(t, err)
+
+	ops := reconciler.Operations.TakeAll()
+	require.Len(t, ops, 1)
+
+	operation, ok := ops[0].(*domain.CreateOrUpdateMBCCronJobOperation)
+	require.True(t, ok)
+	require.Equal(t, overwrittenSchedule, operation.Schedule)
 }
 
 // TestMBCPrimaryReconciler_Finalize_NoProvision tests that Finalize does

--- a/internal/controller/infra/kubernetes_client.go
+++ b/internal/controller/infra/kubernetes_client.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/cybozu-go/mantle/internal/controller/domain"
 	"github.com/cybozu-go/mantle/internal/controller/usecase"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	aerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -44,6 +49,11 @@ func (c *KubernetesClient) ApplyReconcilerOperations(ctx context.Context, operat
 				err = nil
 			}
 
+		case *domain.CreateOrUpdateMBCCronJobOperation:
+			logger.Info("creating or updating CronJob for MBC",
+				"name", operation.CronJobName, "namespace", operation.CronJobNamespace)
+			err = c.createOrUpdateMBCCronJob(ctx, operation)
+
 		default:
 			err = fmt.Errorf("unknown operation type: %T", i)
 		}
@@ -52,4 +62,65 @@ func (c *KubernetesClient) ApplyReconcilerOperations(ctx context.Context, operat
 	}
 
 	return dispatchError
+}
+
+func (c *KubernetesClient) createOrUpdateMBCCronJob(ctx context.Context, op *domain.CreateOrUpdateMBCCronJobOperation) error {
+	cronJob := &batchv1.CronJob{}
+	cronJob.SetName(op.CronJobName)
+	cronJob.SetNamespace(op.CronJobNamespace)
+
+	result, err := ctrl.CreateOrUpdate(ctx, c.Client, cronJob, func() error {
+		cronJob.Spec.Schedule = op.Schedule
+		cronJob.Spec.Suspend = &op.Suspend
+		cronJob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
+		var startingDeadlineSeconds int64 = 3600
+		cronJob.Spec.StartingDeadlineSeconds = &startingDeadlineSeconds
+		var backoffLimit int32 = 10
+		cronJob.Spec.JobTemplate.Spec.BackoffLimit = &backoffLimit
+
+		podSpec := &cronJob.Spec.JobTemplate.Spec.Template.Spec
+		podSpec.ServiceAccountName = op.ServiceAccountName
+		podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+
+		if len(podSpec.Containers) == 0 {
+			podSpec.Containers = append(podSpec.Containers, corev1.Container{})
+		}
+		container := &podSpec.Containers[0]
+		container.Name = "backup"
+		container.Image = op.Image
+		container.Command = []string{
+			"/manager",
+			"backup",
+			"--name", op.MBCName,
+			"--namespace", op.MBCNamespace,
+		}
+		container.ImagePullPolicy = corev1.PullIfNotPresent
+
+		envName := "JOB_NAME"
+		envIndex := slices.IndexFunc(container.Env, func(e corev1.EnvVar) bool {
+			return e.Name == envName
+		})
+		if envIndex == -1 {
+			container.Env = append(container.Env, corev1.EnvVar{Name: envName})
+			envIndex = len(container.Env) - 1
+		}
+		env := &container.Env[envIndex]
+		if env.ValueFrom == nil {
+			env.ValueFrom = &corev1.EnvVarSource{}
+		}
+		if env.ValueFrom.FieldRef == nil {
+			env.ValueFrom.FieldRef = &corev1.ObjectFieldSelector{}
+		}
+		env.ValueFrom.FieldRef.FieldPath = "metadata.labels['batch.kubernetes.io/job-name']"
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update CronJob: %s: %w", op.CronJobName, err)
+	}
+	if result != controllerutil.OperationResultNone {
+		log.FromContext(ctx).Info("CronJob successfully created or updated: " + op.CronJobName)
+	}
+
+	return nil
 }

--- a/internal/controller/mantlebackupconfig_controller.go
+++ b/internal/controller/mantlebackupconfig_controller.go
@@ -5,35 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 	"sync"
 
-	aerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller/domain"
 	"github.com/cybozu-go/mantle/internal/controller/infra"
-	"github.com/cybozu-go/mantle/internal/controller/metrics"
 	"github.com/cybozu-go/mantle/internal/controller/usecase"
-	"github.com/prometheus/client_golang/prometheus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	MantleBackupConfigFinalizerName              = "mantlebackupconfig.mantle.cybozu.io/finalizer"
-	MantleBackupConfigAnnotationManagedClusterID = "mantlebackupconfig.mantle.cybozu.io/managed-cluster-id"
-	MantleBackupConfigCronJobNamePrefix          = "mbc-"
 )
 
 // MantleBackupConfigReconciler reconciles a MantleBackupConfig object.
@@ -87,8 +75,6 @@ func NewMantleBackupConfigReconciler(
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *MantleBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
 	if r.role == RoleSecondary {
 		return ctrl.Result{}, nil
 	}
@@ -103,71 +89,18 @@ func (r *MantleBackupConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// the testing architecture. See https://github.com/cybozu-go/mantle/pull/252#discussion_r3063499989
 	// for details. We should refactor the code as soon as the old tests are removed.
 	r.ucOnce.Do(func() {
-		r.uc = usecase.NewReconcileMBCPrimary(r.managedCephClusterID, infra.NewKubernetesClient(r.Client), cronJobInfo.namespace)
+		r.uc = usecase.NewReconcileMBCPrimary(
+			r.managedCephClusterID,
+			infra.NewKubernetesClient(r.Client),
+			cronJobInfo.namespace,
+			r.overwriteMBCSchedule,
+			cronJobInfo.serviceAccountName,
+			cronJobInfo.image,
+		)
 	})
 
-	if err := r.uc.Run(ctx, req.NamespacedName); err == nil {
-		return ctrl.Result{}, nil
-	} else if !errors.Is(err, domain.ErrNotImplemented) {
+	if err := r.uc.Run(ctx, req.NamespacedName); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to run usecase: %w", err)
-	}
-
-	// Get MantleBackupConfig.
-	var mbc mantlev1.MantleBackupConfig
-	if err := r.Client.Get(ctx, req.NamespacedName, &mbc); err != nil {
-		if aerrors.IsNotFound(err) {
-			logger.Info("MantleBackupConfig not found", "error", err)
-
-			return ctrl.Result{}, nil
-		}
-
-		return ctrl.Result{}, fmt.Errorf("failed to get MantleBackupConfig: %w", err)
-	}
-
-	// Check if we're in charge of the given mbc.
-	var pvc corev1.PersistentVolumeClaim
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: mbc.Namespace, Name: mbc.Spec.PVC}, &pvc); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get PVC: %s: %s: %w", mbc.Namespace, mbc.Spec.PVC, err)
-	}
-	clusterID, err := getCephClusterIDFromPVC(ctx, r.Client, &pvc)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get Ceph cluster ID: %s: %s: %w", mbc.Namespace, mbc.Spec.PVC, err)
-	}
-	if clusterID != r.managedCephClusterID {
-		logger.Info("the target pvc is not managed by this controller")
-
-		return ctrl.Result{}, nil
-	}
-
-	// Set the finalizer if it's not yet set.
-	if !controllerutil.ContainsFinalizer(&mbc, MantleBackupConfigFinalizerName) {
-		if mbc.Annotations == nil {
-			mbc.Annotations = make(map[string]string)
-		}
-		mbc.Annotations[MantleBackupConfigAnnotationManagedClusterID] = r.managedCephClusterID
-
-		controllerutil.AddFinalizer(&mbc, MantleBackupConfigFinalizerName)
-		if err := r.Client.Update(ctx, &mbc); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to add mbc finalizer: %w", err)
-		}
-	}
-
-	// Export metrics.
-	metrics.BackupConfigInfo.With(prometheus.Labels{
-		"persistentvolumeclaim": mbc.Spec.PVC,
-		"resource_namespace":    mbc.ObjectMeta.Namespace,
-		"mantlebackupconfig":    mbc.ObjectMeta.Name,
-	}).Set(1)
-
-	// Create or update the CronJob
-	if err := r.createOrUpdateCronJob(
-		ctx,
-		&mbc,
-		cronJobInfo.namespace,
-		cronJobInfo.serviceAccountName,
-		cronJobInfo.image,
-	); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create or update cronjob: %w", err)
 	}
 
 	return ctrl.Result{}, nil
@@ -205,7 +138,7 @@ func (r *MantleBackupConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, cronJob client.Object) []reconcile.Request {
 				// Extract the MantleBackupConfig's UID, look it up, and enqueue its reconciliation.
 				name := cronJob.GetName()
-				uid, found := strings.CutPrefix(name, MantleBackupConfigCronJobNamePrefix)
+				uid, found := strings.CutPrefix(name, domain.MantleBackupConfigCronJobNamePrefix)
 				if !found {
 					return []reconcile.Request{}
 				}
@@ -232,78 +165,6 @@ func (r *MantleBackupConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			}),
 		).
 		Complete(r)
-}
-
-func (r *MantleBackupConfigReconciler) createOrUpdateCronJob(ctx context.Context, mbc *mantlev1.MantleBackupConfig, namespace, serviceAccountName, image string) error {
-	logger := log.FromContext(ctx)
-	cronJobName := getMBCCronJobName(mbc)
-
-	cronJob := &batchv1.CronJob{}
-	cronJob.SetName(cronJobName)
-	cronJob.SetNamespace(namespace)
-
-	op, err := ctrl.CreateOrUpdate(ctx, r.Client, cronJob, func() error {
-		cronJob.Spec.Schedule = mbc.Spec.Schedule
-		if r.overwriteMBCSchedule != "" {
-			cronJob.Spec.Schedule = r.overwriteMBCSchedule
-		}
-
-		cronJob.Spec.Suspend = &mbc.Spec.Suspend
-		cronJob.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
-		var startingDeadlineSeconds int64 = 3600
-		cronJob.Spec.StartingDeadlineSeconds = &startingDeadlineSeconds
-		var backoffLimit int32 = 10
-		cronJob.Spec.JobTemplate.Spec.BackoffLimit = &backoffLimit
-
-		podSpec := &cronJob.Spec.JobTemplate.Spec.Template.Spec
-		podSpec.ServiceAccountName = serviceAccountName
-		podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
-
-		if len(podSpec.Containers) == 0 {
-			podSpec.Containers = append(podSpec.Containers, corev1.Container{})
-		}
-		container := &podSpec.Containers[0]
-		container.Name = "backup"
-		container.Image = image
-		container.Command = []string{
-			"/manager",
-			"backup",
-			"--name", mbc.GetName(),
-			"--namespace", mbc.GetNamespace(),
-		}
-		container.ImagePullPolicy = corev1.PullIfNotPresent
-
-		envName := "JOB_NAME"
-		envIndex := slices.IndexFunc(container.Env, func(e corev1.EnvVar) bool {
-			return e.Name == envName
-		})
-		if envIndex == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{Name: envName})
-			envIndex = len(container.Env) - 1
-		}
-		env := &container.Env[envIndex]
-		if env.ValueFrom == nil {
-			env.ValueFrom = &corev1.EnvVarSource{}
-		}
-		if env.ValueFrom.FieldRef == nil {
-			env.ValueFrom.FieldRef = &corev1.ObjectFieldSelector{}
-		}
-		env.ValueFrom.FieldRef.FieldPath = "metadata.labels['batch.kubernetes.io/job-name']"
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create CronJob: %s: %w", cronJobName, err)
-	}
-	if op != controllerutil.OperationResultNone {
-		logger.Info("CronJob successfully created: " + cronJobName)
-	}
-
-	return nil
-}
-
-func getMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {
-	return MantleBackupConfigCronJobNamePrefix + string(mbc.UID)
 }
 
 var getRunningPod func(ctx context.Context, client client.Client) (*corev1.Pod, error) = getRunningPodImpl

--- a/internal/controller/usecase/reconcile_mbc_primary.go
+++ b/internal/controller/usecase/reconcile_mbc_primary.go
@@ -10,6 +10,8 @@ import (
 	mantlev1 "github.com/cybozu-go/mantle/api/v1"
 	"github.com/cybozu-go/mantle/internal/controller/domain"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	aerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,9 +30,18 @@ func NewReconcileMBCPrimary(
 	managedCephClusterID string,
 	k8sClient KubernetesClient,
 	cronJobNamespace string,
+	overwriteMBCSchedule string,
+	serviceAccountName string,
+	image string,
 ) *ReconcileMBCPrimary {
 	return &ReconcileMBCPrimary{
-		reconciler:       domain.NewMBCPrimaryReconciler(managedCephClusterID),
+		reconciler: domain.NewMBCPrimaryReconciler(
+			managedCephClusterID,
+			overwriteMBCSchedule,
+			cronJobNamespace,
+			serviceAccountName,
+			image,
+		),
 		k8sClient:        k8sClient,
 		cronJobNamespace: cronJobNamespace,
 	}
@@ -53,44 +64,19 @@ func (r *ReconcileMBCPrimary) Run(ctx context.Context, mbcNamespacedName types.N
 		return err
 	}
 
-	cronJob, err := getResource[batchv1.CronJob](ctx, r.k8sClient, domain.GetMBCCronJobName(mbc), r.cronJobNamespace)
-	if err != nil && !aerrors.IsNotFound(err) {
+	origMBC := mbc.DeepCopy()
+	_ = r.reconciler.Operations.TakeAll()
+
+	if mbc.DeletionTimestamp.IsZero() {
+		err = r.runProvision(ctx, mbc)
+	} else {
+		err = r.runFinalize(ctx, mbc)
+	}
+
+	if err != nil {
 		return err
 	}
 
-	if mbc.DeletionTimestamp.IsZero() {
-		return r.runProvision()
-	}
-
-	return r.runFinalize(ctx, mbc, cronJob)
-}
-
-func (r *ReconcileMBCPrimary) runProvision() error {
-	err := r.reconciler.Provision()
-	if err != nil {
-		return fmt.Errorf("provision failed: %w", err)
-	}
-
-	return nil
-}
-
-func (r *ReconcileMBCPrimary) runFinalize(
-	ctx context.Context,
-	mbc *mantlev1.MantleBackupConfig,
-	cronJob *batchv1.CronJob,
-) error {
-	// Run finalize logic
-	origMBC := mbc.DeepCopy()
-	// Discard any leftover operations from a previous reconcile cycle that
-	// may have failed partway through, ensuring a clean slate.
-	_ = r.reconciler.Operations.TakeAll()
-
-	err := r.reconciler.Finalize(mbc, cronJob)
-	if err != nil {
-		return fmt.Errorf("finalize failed: %w", err)
-	}
-
-	// Persist changes
 	if !equality.Semantic.DeepEqual(origMBC, mbc) {
 		err := r.k8sClient.Update(ctx, mbc)
 		if err != nil {
@@ -101,6 +87,63 @@ func (r *ReconcileMBCPrimary) runFinalize(
 	err = r.k8sClient.ApplyReconcilerOperations(ctx, r.reconciler.Operations.TakeAll())
 	if err != nil {
 		return fmt.Errorf("failed to apply reconciler operations: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ReconcileMBCPrimary) runProvision(ctx context.Context, mbc *mantlev1.MantleBackupConfig) error {
+	storageClass, err := r.getPVCStorageClass(ctx, mbc)
+	if err != nil {
+		return fmt.Errorf("failed to get PVC StorageClass: %w", err)
+	}
+
+	err = r.reconciler.Provision(mbc, storageClass)
+	if err != nil {
+		return fmt.Errorf("provision failed: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ReconcileMBCPrimary) getPVCStorageClass(
+	ctx context.Context, mbc *mantlev1.MantleBackupConfig,
+) (*storagev1.StorageClass, error) {
+	pvc, err := getResource[corev1.PersistentVolumeClaim](
+		ctx, r.k8sClient, mbc.Spec.PVC, mbc.Namespace,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PVC: %s: %s: %w", mbc.Namespace, mbc.Spec.PVC, err)
+	}
+
+	if pvc.Spec.StorageClassName == nil {
+		return nil, nil //nolint:nilnil // nil StorageClass signals "not responsible" to domain.Provision
+	}
+
+	storageClass, err := getResource[storagev1.StorageClass](
+		ctx, r.k8sClient, *pvc.Spec.StorageClassName, "",
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get StorageClass: %s: %w", *pvc.Spec.StorageClassName, err,
+		)
+	}
+
+	return storageClass, nil
+}
+
+func (r *ReconcileMBCPrimary) runFinalize(
+	ctx context.Context,
+	mbc *mantlev1.MantleBackupConfig,
+) error {
+	cronJob, err := getResource[batchv1.CronJob](ctx, r.k8sClient, domain.GetMBCCronJobName(mbc), r.cronJobNamespace)
+	if err != nil && !aerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get CronJob: %w", err)
+	}
+
+	err = r.reconciler.Finalize(mbc, cronJob)
+	if err != nil {
+		return fmt.Errorf("finalize failed: %w", err)
 	}
 
 	return nil

--- a/internal/controller/usecase/reconcile_mbc_primary_test.go
+++ b/internal/controller/usecase/reconcile_mbc_primary_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	aerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -74,117 +76,254 @@ func TestMain(m *testing.M) {
 }
 
 func newUsecase(cephClusterID, cronJobNamespace string) *usecase.ReconcileMBCPrimary {
-	return usecase.NewReconcileMBCPrimary(cephClusterID, infra.NewKubernetesClient(k8sClient), cronJobNamespace)
+	return usecase.NewReconcileMBCPrimary(
+		cephClusterID,
+		infra.NewKubernetesClient(k8sClient),
+		cronJobNamespace,
+		"",
+		"sa-name",
+		"controller-image",
+	)
 }
 
-//nolint:funlen // After we implement the provision logic, the length will be reduced.
-func TestRun_FinalizePath_Success(t *testing.T) {
-	t.Parallel()
+type testEnvFixture struct {
+	mbcName          string
+	mbcNamespace     string
+	cronJobNamespace string
+	cephClusterID    string
+	pvcName          string
+}
 
-	mbcName := util.GetUniqueName("mbc-")
-	mbcNamespace := util.GetUniqueName("ns-")
-	cronJobNamespace := util.GetUniqueName("ns-")
-	cephClusterID := util.GetUniqueName("managed-ceph-cluster-id")
+func setupTestEnv(t *testing.T, cephClusterID string) *testEnvFixture {
+	t.Helper()
 
-	// Create namespaces
-	for _, ns := range []string{mbcNamespace, cronJobNamespace} {
+	fixture := &testEnvFixture{
+		mbcName:          util.GetUniqueName("mbc-"),
+		mbcNamespace:     util.GetUniqueName("ns-"),
+		cronJobNamespace: util.GetUniqueName("ns-"),
+		cephClusterID:    cephClusterID,
+		pvcName:          util.GetUniqueName("pvc-"),
+	}
+
+	scName := util.GetUniqueName("sc-")
+
+	for _, ns := range []string{fixture.mbcNamespace, fixture.cronJobNamespace} {
 		err := k8sClient.Create(t.Context(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: ns},
 		})
 		require.NoError(t, err)
 	}
 
-	// Create MBC
-	mbc := &mantlev1.MantleBackupConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mbcName,
-			Namespace: mbcNamespace,
-			// FIXME: After we implement the provision logic, we should not set
-			// the finalizer and annotation manually in this test.
-			Finalizers: []string{
-				domain.MantleBackupConfigFinalizerName,
-			},
-			Annotations: map[string]string{
-				domain.MantleBackupConfigAnnotationManagedClusterID: cephClusterID,
-			},
-		},
-		Spec: mantlev1.MantleBackupConfigSpec{
-			PVC:      "pvc-name",
-			Schedule: "0 0 * * *",
-			Expire:   "2w",
-			Suspend:  false,
-		},
-	}
-	err := k8sClient.Create(t.Context(), mbc)
+	err := k8sClient.Create(t.Context(), &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: scName},
+		Provisioner: "test.rbd.csi.ceph.com",
+		Parameters:  map[string]string{"clusterID": cephClusterID},
+	})
 	require.NoError(t, err)
 
-	// Create CronJob
-	// FIXME: After we implement the provision logic, we should not create the CronJob manually in this test.
-	err = k8sClient.Create(t.Context(), &batchv1.CronJob{
+	err = k8sClient.Create(t.Context(), &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      domain.GetMBCCronJobName(mbc),
-			Namespace: cronJobNamespace,
+			Name:      fixture.pvcName,
+			Namespace: fixture.mbcNamespace,
 		},
-		Spec: batchv1.CronJobSpec{
-			Schedule: "0 0 * * *",
-			JobTemplate: batchv1.JobTemplateSpec{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name:  "backup",
-								Image: "backup-image",
-							}},
-							RestartPolicy: corev1.RestartPolicyOnFailure,
-						},
-					},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
 				},
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	// Delete MBC to trigger the finalization logic
+	return fixture
+}
+
+func (f *testEnvFixture) createMBC(
+	t *testing.T,
+) *mantlev1.MantleBackupConfig {
+	t.Helper()
+
+	mbc := &mantlev1.MantleBackupConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f.mbcName,
+			Namespace: f.mbcNamespace,
+		},
+		Spec: mantlev1.MantleBackupConfigSpec{
+			PVC:      f.pvcName,
+			Schedule: "0 0 * * *",
+			Expire:   "2w",
+			Suspend:  false,
+		},
+	}
+
+	err := k8sClient.Create(t.Context(), mbc)
+	require.NoError(t, err)
+
+	return mbc
+}
+
+func (f *testEnvFixture) mbcNN() types.NamespacedName {
+	return types.NamespacedName{Name: f.mbcName, Namespace: f.mbcNamespace}
+}
+
+func (f *testEnvFixture) provisionMBC(
+	t *testing.T, useCase *usecase.ReconcileMBCPrimary,
+) {
+	t.Helper()
+
+	err := useCase.Run(t.Context(), f.mbcNN())
+	require.NoError(t, err)
+
+	err = useCase.Run(t.Context(), f.mbcNN())
+	require.NoError(t, err)
+}
+
+func TestRun_FinalizePath_Success(t *testing.T) {
+	t.Parallel()
+
+	fixture := setupTestEnv(t, util.GetUniqueName("ceph-cluster-id"))
+	mbc := fixture.createMBC(t)
+	useCase := newUsecase(fixture.cephClusterID, fixture.cronJobNamespace)
+
+	fixture.provisionMBC(t, useCase)
+
+	cronJobNN := types.NamespacedName{
+		Name:      domain.GetMBCCronJobName(mbc),
+		Namespace: fixture.cronJobNamespace,
+	}
+
+	err := k8sClient.Get(t.Context(), cronJobNN, &batchv1.CronJob{})
+	require.NoError(t, err)
+
 	err = k8sClient.Delete(t.Context(), mbc)
 	require.NoError(t, err)
 
-	// Run the usecase
-	useCase := newUsecase(cephClusterID, cronJobNamespace)
-	err = useCase.Run(
-		t.Context(),
-		types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
-	)
+	err = useCase.Run(t.Context(), fixture.mbcNN())
 	require.NoError(t, err)
 
-	// Verify that the CronJob is deleted
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		err = k8sClient.Get(
-			t.Context(),
-			types.NamespacedName{Name: domain.GetMBCCronJobName(mbc), Namespace: cronJobNamespace},
-			&batchv1.CronJob{},
-		)
+		err = k8sClient.Get(t.Context(), cronJobNN, &batchv1.CronJob{})
 		assert.Error(collect, err)
 		assert.True(collect, aerrors.IsNotFound(err))
 	}, 5*time.Second, 1*time.Second)
 
-	// Run the usecase a second time to verify that the finalizer is removed.
-	// The first Run deletes the CronJob; the second Run should remove the finalizer.
-	err = useCase.Run(
-		t.Context(),
-		types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
-	)
+	err = useCase.Run(t.Context(), fixture.mbcNN())
 	require.NoError(t, err)
 
-	// Verify that the MBC has been garbage-collected by the API server.
-	// Once the finalizer is removed from a resource with DeletionTimestamp,
-	// Kubernetes deletes it automatically.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		err = k8sClient.Get(
-			t.Context(),
-			types.NamespacedName{Name: mbcName, Namespace: mbcNamespace},
-			&mantlev1.MantleBackupConfig{},
+			t.Context(), fixture.mbcNN(), &mantlev1.MantleBackupConfig{},
 		)
 		assert.Error(collect, err)
 		assert.True(collect, aerrors.IsNotFound(err))
 	}, 5*time.Second, 1*time.Second)
+}
+
+func TestRun_ProvisionPath_FullLifecycle(t *testing.T) {
+	t.Parallel()
+
+	cephClusterID := util.GetUniqueName("ceph-cluster-id")
+	fixture := setupTestEnv(t, cephClusterID)
+	mbc := fixture.createMBC(t)
+	useCase := newUsecase(cephClusterID, fixture.cronJobNamespace)
+
+	err := useCase.Run(t.Context(), fixture.mbcNN())
+	require.NoError(t, err)
+
+	var updatedMBC mantlev1.MantleBackupConfig
+
+	err = k8sClient.Get(t.Context(), fixture.mbcNN(), &updatedMBC)
+	require.NoError(t, err)
+	require.Contains(t, updatedMBC.Finalizers, domain.MantleBackupConfigFinalizerName)
+	require.Equal(t, cephClusterID,
+		updatedMBC.Annotations[domain.MantleBackupConfigAnnotationManagedClusterID])
+
+	err = useCase.Run(t.Context(), fixture.mbcNN())
+	require.NoError(t, err)
+
+	cronJobNN := types.NamespacedName{
+		Name:      domain.GetMBCCronJobName(mbc),
+		Namespace: fixture.cronJobNamespace,
+	}
+
+	var cronJob batchv1.CronJob
+
+	err = k8sClient.Get(t.Context(), cronJobNN, &cronJob)
+	require.NoError(t, err)
+	require.Equal(t, "0 0 * * *", cronJob.Spec.Schedule)
+	require.False(t, *cronJob.Spec.Suspend)
+	require.Equal(t, batchv1.ForbidConcurrent, cronJob.Spec.ConcurrencyPolicy)
+	require.Equal(t, "sa-name",
+		cronJob.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName)
+	require.Equal(t, "controller-image",
+		cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestRun_ProvisionPath_NotResponsibleCluster(t *testing.T) {
+	t.Parallel()
+
+	fixture := setupTestEnv(t, "other-cluster-id")
+	mbc := fixture.createMBC(t)
+	useCase := newUsecase("my-cluster-id", fixture.cronJobNamespace)
+
+	err := useCase.Run(t.Context(), fixture.mbcNN())
+	require.NoError(t, err)
+
+	var updatedMBC mantlev1.MantleBackupConfig
+
+	err = k8sClient.Get(t.Context(), fixture.mbcNN(), &updatedMBC)
+	require.NoError(t, err)
+	require.NotContains(t, updatedMBC.Finalizers, domain.MantleBackupConfigFinalizerName)
+
+	cronJobNN := types.NamespacedName{
+		Name:      domain.GetMBCCronJobName(mbc),
+		Namespace: fixture.cronJobNamespace,
+	}
+
+	err = k8sClient.Get(t.Context(), cronJobNN, &batchv1.CronJob{})
+	require.True(t, aerrors.IsNotFound(err))
+}
+
+func TestRun_ProvisionPath_CronJobUpdate(t *testing.T) {
+	t.Parallel()
+
+	cephClusterID := util.GetUniqueName("ceph-cluster-id")
+	fixture := setupTestEnv(t, cephClusterID)
+	mbc := fixture.createMBC(t)
+	useCase := newUsecase(cephClusterID, fixture.cronJobNamespace)
+
+	fixture.provisionMBC(t, useCase)
+
+	cronJobNN := types.NamespacedName{
+		Name:      domain.GetMBCCronJobName(mbc),
+		Namespace: fixture.cronJobNamespace,
+	}
+
+	var cronJob batchv1.CronJob
+
+	err := k8sClient.Get(t.Context(), cronJobNN, &cronJob)
+	require.NoError(t, err)
+	require.Equal(t, "0 0 * * *", cronJob.Spec.Schedule)
+	require.False(t, *cronJob.Spec.Suspend)
+
+	var updatedMBC mantlev1.MantleBackupConfig
+
+	err = k8sClient.Get(t.Context(), fixture.mbcNN(), &updatedMBC)
+	require.NoError(t, err)
+
+	updatedMBC.Spec.Schedule = "0 12 * * *"
+	updatedMBC.Spec.Suspend = true
+	err = k8sClient.Update(t.Context(), &updatedMBC)
+	require.NoError(t, err)
+
+	err = useCase.Run(t.Context(), fixture.mbcNN())
+	require.NoError(t, err)
+
+	err = k8sClient.Get(t.Context(), cronJobNN, &cronJob)
+	require.NoError(t, err)
+	require.Equal(t, "0 12 * * *", cronJob.Spec.Schedule)
+	require.True(t, *cronJob.Spec.Suspend)
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -3,10 +3,11 @@ package util
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 )
 
 var (
-	usedResourceNames = make(map[string]bool)
+	usedResourceNames = sync.Map{}
 )
 
 func GetUniqueName(prefix string) string {
@@ -16,10 +17,10 @@ func GetUniqueName(prefix string) string {
 		buf[i] = letters[rand.Intn(len(letters))]
 	}
 	name := fmt.Sprintf("%s%s", prefix, string(buf))
-	if usedResourceNames[name] {
+	_, loaded := usedResourceNames.LoadOrStore(name, true)
+	if loaded {
 		return GetUniqueName(prefix)
 	}
-	usedResourceNames[name] = true
 
 	return name
 }


### PR DESCRIPTION
Move the MantleBackupConfig provision logic (PVC cluster ID lookup, finalizer/annotation setup, metrics export, CronJob create-or-update) from the controller package into the domain/usecase/infra layers, following the same architecture established in PRs #250 and #252.

Remove the ErrNotImplemented fallback pattern and the duplicated createOrUpdateCronJob/getMBCCronJobName from the controller.

Add unit tests for domain.Provision and integration tests for the provision path in the usecase layer.

- 1/n: https://github.com/cybozu-go/mantle/pull/250
- 2/n: https://github.com/cybozu-go/mantle/pull/252