### PR TITLE
controller: remove controllerExpandSecretRef and controllerPublishSecretRef from static PVs

### DIFF
--- a/ceph/test/cluster/rbd.go
+++ b/ceph/test/cluster/rbd.go
@@ -102,9 +102,8 @@ func zeroOutVolume(namespace, pvcName string) error {
 		},
 	}
 	zeroOutPV.Spec.CSI = &corev1.CSIPersistentVolumeSource{
-		Driver:                    origPV.Spec.CSI.Driver,
-		ControllerExpandSecretRef: origPV.Spec.CSI.ControllerExpandSecretRef,
-		NodeStageSecretRef:        origPV.Spec.CSI.NodeStageSecretRef,
+		Driver:             origPV.Spec.CSI.Driver,
+		NodeStageSecretRef: origPV.Spec.CSI.NodeStageSecretRef,
 		VolumeAttributes: map[string]string{
 			"clusterID":     origPV.Spec.CSI.VolumeAttributes["clusterID"],
 			"imageFeatures": origPV.Spec.CSI.VolumeAttributes["imageFeatures"],

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -2352,9 +2352,8 @@ func (r *MantleBackupReconciler) createStaticPVIfNotExists(
 
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
-					Driver:                    basePV.Spec.CSI.Driver,
-					ControllerExpandSecretRef: basePV.Spec.CSI.ControllerExpandSecretRef,
-					NodeStageSecretRef:        basePV.Spec.CSI.NodeStageSecretRef,
+					Driver:             basePV.Spec.CSI.Driver,
+					NodeStageSecretRef: basePV.Spec.CSI.NodeStageSecretRef,
 					VolumeAttributes: map[string]string{
 						"clusterID":     basePV.Spec.CSI.VolumeAttributes["clusterID"],
 						"imageFeatures": feature,

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -2418,10 +2418,6 @@ var _ = Describe("import", func() {
 				corev1.ResourceStorage: resource.MustParse("1Gi"),
 			}
 			pvDriver := "test-pv-driver"
-			pvControllerExpandSecretRef := corev1.SecretReference{
-				Name:      "test-pv-cesr-name",
-				Namespace: "test-pv-cesr-ns",
-			}
 			pvNodeStageSecretRef := corev1.SecretReference{
 				Name:      "test-pv-nssr-name",
 				Namespace: "test-pv-nssr-ns",
@@ -2447,9 +2443,8 @@ var _ = Describe("import", func() {
 						Capacity: pvCapacity,
 						PersistentVolumeSource: corev1.PersistentVolumeSource{
 							CSI: &corev1.CSIPersistentVolumeSource{
-								Driver:                    pvDriver,
-								ControllerExpandSecretRef: &pvControllerExpandSecretRef,
-								NodeStageSecretRef:        &pvNodeStageSecretRef,
+								Driver:             pvDriver,
+								NodeStageSecretRef: &pvNodeStageSecretRef,
 								VolumeAttributes: map[string]string{
 									"clusterID":     pvClusterID,
 									"imageFeatures": pvImageFeatures,
@@ -2484,9 +2479,8 @@ var _ = Describe("import", func() {
 				},
 				PersistentVolumeSource: corev1.PersistentVolumeSource{
 					CSI: &corev1.CSIPersistentVolumeSource{
-						Driver:                    pvDriver,
-						ControllerExpandSecretRef: &pvControllerExpandSecretRef,
-						NodeStageSecretRef:        &pvNodeStageSecretRef,
+						Driver:             pvDriver,
+						NodeStageSecretRef: &pvNodeStageSecretRef,
 						VolumeAttributes: map[string]string{
 							"clusterID":     pvClusterID,
 							"imageFeatures": pvImageFeatures,
@@ -2808,9 +2802,8 @@ var _ = Describe("MantleBackupReconciler", func() {
 				},
 				PersistentVolumeSource: corev1.PersistentVolumeSource{
 					CSI: &corev1.CSIPersistentVolumeSource{
-						Driver:                    pvSrc.Spec.CSI.Driver,
-						ControllerExpandSecretRef: pvSrc.Spec.CSI.ControllerPublishSecretRef,
-						NodeStageSecretRef:        pvSrc.Spec.CSI.NodeStageSecretRef,
+						Driver:             pvSrc.Spec.CSI.Driver,
+						NodeStageSecretRef: pvSrc.Spec.CSI.NodeStageSecretRef,
 						VolumeAttributes: map[string]string{
 							"clusterID":     pvSrc.Spec.CSI.VolumeAttributes["clusterID"],
 							"imageFeatures": pvSrc.Spec.CSI.VolumeAttributes["imageFeatures"] + ",deep-flatten",

--- a/internal/controller/mantlerestore_controller.go
+++ b/internal/controller/mantlerestore_controller.go
@@ -284,6 +284,8 @@ func (r *MantleRestoreReconciler) createRestoringPVIfNotExists(ctx context.Conte
 		Namespace: pvcNamespace,
 		Name:      pvcName,
 	}
+	newPV.Spec.CSI.ControllerPublishSecretRef = nil
+	newPV.Spec.CSI.ControllerExpandSecretRef = nil
 	newPV.Spec.CSI.VolumeAttributes = map[string]string{
 		"clusterID":     srcPV.Spec.CSI.VolumeAttributes["clusterID"],
 		"pool":          srcPV.Spec.CSI.VolumeAttributes["pool"],


### PR DESCRIPTION
According to [the document of cephcsi](https://github.com/ceph/ceph-csi/blob/v3.16.2/docs/static-pvc.md), we shouldn't set `controllerExpandSecretRef` or `controllerPublishSecretRef` to static PVs.

`controllerExpandSecretRef` is read by external-resizer and passed to cephcsi's `ControllerExpandVolume` and `ControllerModifyVolume`. Static PVs cannot be expanded or modified, so this secret won't be used.

`controllerPublishSecretRef` is read by external-attacher and passed to cephcsi's `ControllerPublishVolume` and `ControllerUnpublishVolume`. When it's set, cephcsi's `ControllerUnpublishVolume` tries to parse the volume ID. However, static PVs generally have custom volume IDs (and indeed, Mantle sets MantleRestore's name), so it fails to parse them (cf. https://github.com/ceph/ceph-csi/blob/v3.16.2/internal/rbd/controllerserver.go#L1724-L1751 ). When `controllerPublishSecretRef` isn't set, this parsing logic is totally skipped (probably accidentally?), so `ControllerUnpublishVolume` completes successfully.

Overall, these two secret refs shouldn't be set from the perspective of the documentation of cephcsi and of practice use.

The CI for this PR uses Rook v1.18.6. [Another (DNM) PR](https://github.com/cybozu-go/mantle/pull/281) is created so that we can confirm that Rook v1.19.5 still works with this patch.