### PR TITLE
doc: remove unnecessary lines from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,1 @@
-# Maintainers can approve and merge PRs.
-# @llamerada-jp: Yuji Ito
-# @satoru-takeuchi: Satoru Takeuchi
-# @ushitora-anqou: Ryotaro Banno
-# @molpako: Kyori Sakao
-# @skoya76: Kohya Shiozaki
 * @cybozu-go/mantle-maintainers


### PR DESCRIPTION
We can see the maintainers on a GitHub public page. So it's not necessary to list them in CODEOWNERS.

https://github.com/orgs/cybozu-go/teams/mantle-maintainers