### PR TITLE
ci: add permissions

### DIFF
--- a/.github/workflows/ceph-export-diff-release.yaml
+++ b/.github/workflows/ceph-export-diff-release.yaml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "ceph-export-diff-v*.*.*.*"
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: mantle_large_runner_16core

--- a/.github/workflows/ceph-export-diff-test.yaml
+++ b/.github/workflows/ceph-export-diff-test.yaml
@@ -4,6 +4,8 @@ on:
     paths:
       - "ceph/**"
       - "!ceph/README.md"
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: mantle_large_runner_16core

--- a/.github/workflows/check-do-not-merge.yaml
+++ b/.github/workflows/check-do-not-merge.yaml
@@ -3,7 +3,7 @@ name: Check Do Not Merge Label
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
+permissions: {}
 jobs:
   check-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-multiple-k8s-clusters.yaml
+++ b/.github/workflows/e2e-multiple-k8s-clusters.yaml
@@ -10,6 +10,8 @@ on:
       - "CODEOWNERS"
     branches:
       - "main"
+permissions:
+  contents: read
 
 # Cancel any ongoing workflows on the same branch to avoid unnecessary fees.
 # cf. https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-and-the-default-behavior

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,8 @@ on:
       - "NOTICE"
     branches:
       - "main"
-
+permissions:
+  contents: read
 jobs:
   build:
     strategy:

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,6 +2,9 @@ name: "Release Charts"
 
 on: "workflow_dispatch"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "main"
+permissions:
+  contents: read
 jobs:
   build:
     name: "build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "v*"
+permissions:
+  contents: write
+  packages: write
 jobs:
   release:
     name: "release"


### PR DESCRIPTION
Add `permissions` field to the CI workflows.

The following workflows are tested on this PR:

- e2e-multiple-k8s-clusters.yaml
- e2e.yaml
- main.yaml
- check-do-not-merge.yaml

However, the following workflows cannot be tested (I think), so I'd like to merge them first and fix any issues later.

- ceph-export-diff-release.yaml
- ceph-export-diff-test.yaml
- helm-release.yaml
- release.yaml
