### PR TITLE
refactor(domain): extract GetMBCUIDFromCronJobName from controller

### DIFF
--- a/internal/controller/domain/mbc_primary_reconciler.go
+++ b/internal/controller/domain/mbc_primary_reconciler.go
@@ -50,6 +50,12 @@ func GetMBCCronJobName(mbc *mantlev1.MantleBackupConfig) string {
 	return MantleBackupConfigCronJobNamePrefix + string(mbc.UID)
 }
 
+// GetMBCUIDFromCronJobName extracts the MantleBackupConfig UID from a CronJob name.
+// It returns the UID and true if the name has the expected prefix, or ("", false) otherwise.
+func GetMBCUIDFromCronJobName(cronJobName string) (string, bool) {
+	return strings.CutPrefix(cronJobName, MantleBackupConfigCronJobNamePrefix)
+}
+
 // MBCPrimaryReconciler is a reconciler for MantleBackupConfig resources
 // running on the primary cluster.
 type MBCPrimaryReconciler struct {

--- a/internal/controller/domain/mbc_primary_reconciler_test.go
+++ b/internal/controller/domain/mbc_primary_reconciler_test.go
@@ -344,3 +344,28 @@ func TestMBCPrimaryReconciler_Finalize_NotResponsibleStorageClass(t *testing.T) 
 	require.Equal(t, origMBC, mbc)
 	require.Empty(t, reconciler.Operations.TakeAll())
 }
+
+func TestGetMBCUIDFromCronJobName_ValidName(t *testing.T) {
+	t.Parallel()
+
+	uid, found := domain.GetMBCUIDFromCronJobName(domain.MantleBackupConfigCronJobNamePrefix + "some-uid-value")
+	require.True(t, found)
+	require.Equal(t, "some-uid-value", uid)
+}
+
+func TestGetMBCUIDFromCronJobName_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	_, found := domain.GetMBCUIDFromCronJobName("other-prefix-some-uid")
+	require.False(t, found)
+}
+
+func TestGetMBCUIDFromCronJobName_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mbc := newMBC()
+	cronJobName := domain.GetMBCCronJobName(mbc)
+	uid, found := domain.GetMBCUIDFromCronJobName(cronJobName)
+	require.True(t, found)
+	require.Equal(t, string(mbc.UID), uid)
+}

--- a/internal/controller/mantlebackupconfig_controller.go
+++ b/internal/controller/mantlebackupconfig_controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -137,8 +136,7 @@ func (r *MantleBackupConfigReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			&batchv1.CronJob{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, cronJob client.Object) []reconcile.Request {
 				// Extract the MantleBackupConfig's UID, look it up, and enqueue its reconciliation.
-				name := cronJob.GetName()
-				uid, found := strings.CutPrefix(name, domain.MantleBackupConfigCronJobNamePrefix)
+				uid, found := domain.GetMBCUIDFromCronJobName(cronJob.GetName())
 				if !found {
 					return []reconcile.Request{}
 				}


### PR DESCRIPTION
Extract the CronJob-name-to-MBC-UID mapping logic from the inline closure in SetupWithManager into a domain-layer function.

- 1/4: https://github.com/cybozu-go/mantle/pull/250
- 2/4: https://github.com/cybozu-go/mantle/pull/252
- 3/4: https://github.com/cybozu-go/mantle/pull/277