### PR TITLE
e2e: use K8s v1.35.1 supported by the minikube in use

### DIFF
--- a/.github/workflows/e2e-multiple-k8s-clusters.yaml
+++ b/.github/workflows/e2e-multiple-k8s-clusters.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 1.35.4
+          - 1.35.1
         backup-transfer-part-size:
           - 3Mi # smaller than the PVC size
         label-filter:
@@ -39,10 +39,10 @@ jobs:
           - "!//" # select unlabelled tests
         include:
           # testing various backup-transfer-part-size
-          - kubernetes-version: 1.35.4
+          - kubernetes-version: 1.35.1
             backup-transfer-part-size: 10Mi # equal to the PVC size
             label-filter: various-transfer-part-size
-          - kubernetes-version: 1.35.4
+          - kubernetes-version: 1.35.1
             backup-transfer-part-size: 200Gi # greater than the PVC size
             label-filter: various-transfer-part-size
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version:
-          - 1.35.4
+          - 1.35.1
           - 1.34.4
     runs-on: "ubuntu-22.04"
     timeout-minutes: 60

--- a/versions.mk
+++ b/versions.mk
@@ -2,8 +2,9 @@
 CONTROLLER_TOOLS_VERSION := v0.20.1
 # https://github.com/helm/helm/releases
 HELM_VERSION := 4.2.0
-# It is set by CI using the environment variable, use conditional assignment.
-KUBERNETES_VERSION := 1.35.4
+# Use a Kubernetes version supported by the minikube version below.
+# The patch version may differ from the k8s patch version in go.mod.
+KUBERNETES_VERSION := 1.35.1
 # https://github.com/kubernetes-sigs/kustomize/releases
 KUSTOMIZE_VERSION := v5.8.1
 # https://github.com/kubernetes/minikube/releases


### PR DESCRIPTION
[Minikube v1.38.1](https://github.com/kubernetes/minikube/releases/tag/v1.38.1) supports Kubernetes up to v1.35.1 as its latest version.