### PR TITLE
metrics: add backup_exported_diff_size_bytes

### DIFF
--- a/internal/controller/internal/objectstorage/objectstorage.go
+++ b/internal/controller/internal/objectstorage/objectstorage.go
@@ -7,4 +7,7 @@ type Bucket interface {
 
 	// Delete deletes the specified object. Delete will return nil if the object is not found.
 	Delete(ctx context.Context, path string) error
+
+	// GetSize returns the size of the specified object in bytes.
+	GetSize(ctx context.Context, path string) (int64, error)
 }

--- a/internal/controller/internal/objectstorage/objectstorage_mock.go
+++ b/internal/controller/internal/objectstorage/objectstorage_mock.go
@@ -68,3 +68,18 @@ func (mr *MockBucketMockRecorder) Exists(ctx, path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockBucket)(nil).Exists), ctx, path)
 }
+
+// GetSize mocks base method.
+func (m *MockBucket) GetSize(ctx context.Context, path string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSize", ctx, path)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSize indicates an expected call of GetSize.
+func (mr *MockBucketMockRecorder) GetSize(ctx, path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSize", reflect.TypeOf((*MockBucket)(nil).GetSize), ctx, path)
+}

--- a/internal/controller/internal/objectstorage/s3.go
+++ b/internal/controller/internal/objectstorage/s3.go
@@ -78,6 +78,21 @@ func (b *S3Bucket) Exists(ctx context.Context, key string) (bool, error) {
 	return true, nil
 }
 
+func (b *S3Bucket) GetSize(ctx context.Context, key string) (int64, error) {
+	output, err := b.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: &b.bucketName,
+		Key:    &key,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("HeadObject failed: %s: %s: %s: %w", b.endpoint, b.bucketName, key, err)
+	}
+	if output.ContentLength == nil {
+		return 0, fmt.Errorf("HeadObject returned nil ContentLength: %s: %s: %s", b.endpoint, b.bucketName, key)
+	}
+
+	return *output.ContentLength, nil
+}
+
 func (b *S3Bucket) Delete(ctx context.Context, key string) error {
 	if _, err := b.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &b.bucketName,

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -134,6 +134,13 @@ type MantleBackupReconciler struct {
 	objectStorageClient    objectstorage.Bucket
 	proxySettings          *ProxySettings
 	backupTransferPartSize resource.Quantity
+
+	exportedDiffSizeCache map[types.UID]exportedDiffSizeCacheEntry
+}
+
+type exportedDiffSizeCacheEntry struct {
+	largestPartNum int
+	totalSize      int64
 }
 
 // NewMantleBackupReconciler returns NodeReconciler.
@@ -164,6 +171,7 @@ func NewMantleBackupReconciler(
 		objectStorageSettings:  objectStorageSettings,
 		proxySettings:          proxySettings,
 		backupTransferPartSize: backupTransferPartSize,
+		exportedDiffSizeCache:  map[types.UID]exportedDiffSizeCacheEntry{},
 	}
 }
 
@@ -538,6 +546,17 @@ func (r *MantleBackupReconciler) reconcileAsPrimary(ctx context.Context, backup 
 
 	if !backup.DeletionTimestamp.IsZero() {
 		return reconcile.Succeeded()
+	}
+
+	// Restore the metric after a controller restart. startUpload also calls Set(), but
+	// the replicate path below may return early before reaching startUpload, so we also
+	// set it here, which is always reached. Failures are only logged, not returned, so
+	// that a transient object storage error while collecting this observability metric
+	// does not block verification, replication, or cleanup.
+	if largestCompletedUploadPartNum, err := r.getLargestCompletedUploadPartNum(ctx, backup); err != nil {
+		log.FromContext(ctx).Error(err, "failed to get largest completed upload part number")
+	} else if err := r.setExportedDiffSizeMetric(ctx, backup, largestCompletedUploadPartNum); err != nil {
+		log.FromContext(ctx).Error(err, "failed to set exported diff size metric")
 	}
 
 	if !backup.IsVerifiedTrue() && !backup.IsVerifiedFalse() {
@@ -1002,6 +1021,14 @@ func (r *MantleBackupReconciler) finalizeStandalone(
 		return result.WrapIfError("failed to remove RBD snapshot from backup")
 	}
 
+	_ = metrics.BackupExportedDiffSizeBytes.Delete(prometheus.Labels{
+		"persistentvolumeclaim": backup.Spec.PVC,
+		"resource_namespace":    backup.GetNamespace(),
+		"mantlebackup":          backup.GetName(),
+	})
+
+	delete(r.exportedDiffSizeCache, backup.GetUID())
+
 	controllerutil.RemoveFinalizer(backup, MantleBackupFinalizerName)
 	if err := r.Update(ctx, backup); err != nil {
 		logger.Error(err, "failed to remove finalizer", "finalizer", MantleBackupFinalizerName)
@@ -1330,45 +1357,14 @@ func (r *MantleBackupReconciler) handleCompletedJobsOfComponent(
 	componentPrefix string,
 	hookPostJobDeletion *func(partNum int) error,
 ) (int, *reconcile.Result) {
-	// List all the Jobs
-	var jobList batchv1.JobList
-	if err := r.List(ctx, &jobList, &client.ListOptions{
-		Namespace: r.managedCephClusterID,
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			"app.kubernetes.io/name":      labelAppNameValue,
-			"app.kubernetes.io/component": componentLabel,
-		}),
-	}); err != nil {
-		return -1, reconcile.Failed("failed to list Jobs: %w", err)
-	}
-
-	// Collect the completed Jobs having the correct prefix.
-	type CompletedJob struct {
-		job     batchv1.Job
-		partNum int
-	}
-	completedJobs := []*CompletedJob{}
-	largestPartNum := -1
-	for _, job := range jobList.Items {
-		if !IsJobConditionTrue(job.Status.Conditions, batchv1.JobComplete) {
-			continue
-		}
-
-		partNum, ok := ExtractPartNumFromComponentJobName(componentPrefix, job.GetName(), backup)
-		if !ok {
-			continue
-		}
-
-		completedJobs = append(completedJobs, &CompletedJob{
-			job:     job,
-			partNum: partNum,
-		})
-
-		largestPartNum = max(largestPartNum, partNum)
+	completedJobs, largestPartNum, result := r.listCompletedJobsOfComponent(ctx, backup, componentLabel, componentPrefix)
+	if result.ShouldReturn() {
+		return -1, result
 	}
 
 	// Delete the completed Jobs other than the latest one
-	for _, job := range completedJobs {
+	for i := range completedJobs {
+		job := &completedJobs[i]
 		if job.partNum == largestPartNum {
 			continue
 		}
@@ -1391,6 +1387,50 @@ func (r *MantleBackupReconciler) handleCompletedJobsOfComponent(
 	}
 
 	return largestPartNum, nil
+}
+
+type completedComponentJob struct {
+	job     batchv1.Job
+	partNum int
+}
+
+// listCompletedJobsOfComponent lists the completed Jobs of the given component that
+// belong to the backup, and returns them together with the largest part number among
+// them (-1 if there is none).
+func (r *MantleBackupReconciler) listCompletedJobsOfComponent(
+	ctx context.Context,
+	backup *mantlev1.MantleBackup,
+	componentLabel string,
+	componentPrefix string,
+) ([]completedComponentJob, int, *reconcile.Result) {
+	var jobList batchv1.JobList
+	if err := r.List(ctx, &jobList, &client.ListOptions{
+		Namespace: r.managedCephClusterID,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app.kubernetes.io/name":      labelAppNameValue,
+			"app.kubernetes.io/component": componentLabel,
+		}),
+	}); err != nil {
+		return nil, -1, reconcile.Failed("failed to list Jobs: %w", err)
+	}
+
+	var completedJobs []completedComponentJob
+	largestPartNum := -1
+	for _, job := range jobList.Items {
+		if !IsJobConditionTrue(job.Status.Conditions, batchv1.JobComplete) {
+			continue
+		}
+
+		partNum, ok := ExtractPartNumFromComponentJobName(componentPrefix, job.GetName(), backup)
+		if !ok {
+			continue
+		}
+
+		completedJobs = append(completedJobs, completedComponentJob{job: job, partNum: partNum})
+		largestPartNum = max(largestPartNum, partNum)
+	}
+
+	return completedJobs, largestPartNum, nil
 }
 
 func IsPartNextToLargestCompletedPart(largestCompletedPartNum *int, partNum int) bool {
@@ -1526,6 +1566,10 @@ func (r *MantleBackupReconciler) startUpload(ctx context.Context, targetBackup *
 		return result.WrapIfError("failed to handle completed upload jobs")
 	}
 
+	if err := r.setExportedDiffSizeMetric(ctx, targetBackup, largestCompletedUploadPartNum); err != nil {
+		log.FromContext(ctx).Error(err, "failed to set exported diff size metric")
+	}
+
 	if result := r.createOrUpdateUploadJobs(
 		ctx,
 		targetBackup,
@@ -1536,6 +1580,74 @@ func (r *MantleBackupReconciler) startUpload(ctx context.Context, targetBackup *
 	}
 
 	return nil
+}
+
+// setExportedDiffSizeMetric HeadObjects the uploaded diff parts up through
+// largestCompletedUploadPartNum, sums their sizes, and overwrites (Set) the
+// backup_exported_diff_size_bytes gauge with that total. Parts already summed in a
+// previous call for this backup (tracked in exportedDiffSizeCache) are not re-fetched;
+// only the newly completed parts are HeadObject'ed and added to the cached total. If
+// exportedDiffSizeCache has no entry for this backup, all the parts are HeadObject'ed
+// once to rebuild it.
+func (r *MantleBackupReconciler) setExportedDiffSizeMetric(
+	ctx context.Context,
+	backup *mantlev1.MantleBackup,
+	largestCompletedUploadPartNum int,
+) error {
+	if largestCompletedUploadPartNum < 0 {
+		return nil
+	}
+
+	if result := r.prepareObjectStorageClient(ctx); result.ShouldReturn() {
+		_, err := result.ToCtrlResult()
+
+		return fmt.Errorf("failed to prepare object storage client: %w", err)
+	}
+
+	cached, ok := r.exportedDiffSizeCache[backup.GetUID()]
+
+	firstPartNum := 0
+	var totalSize int64
+	if ok && cached.largestPartNum <= largestCompletedUploadPartNum {
+		firstPartNum = cached.largestPartNum + 1
+		totalSize = cached.totalSize
+	}
+
+	for partNum := firstPartNum; partNum <= largestCompletedUploadPartNum; partNum++ {
+		key := MakeObjectNameOfExportedData(backup.GetName(), string(backup.GetUID()), partNum)
+		size, err := r.objectStorageClient.GetSize(ctx, key)
+		if err != nil {
+			return fmt.Errorf("failed to get size of exported data part %d: %w", partNum, err)
+		}
+		totalSize += size
+	}
+
+	r.exportedDiffSizeCache[backup.GetUID()] = exportedDiffSizeCacheEntry{
+		largestPartNum: largestCompletedUploadPartNum,
+		totalSize:      totalSize,
+	}
+
+	metrics.BackupExportedDiffSizeBytes.With(prometheus.Labels{
+		"persistentvolumeclaim": backup.Spec.PVC,
+		"resource_namespace":    backup.GetNamespace(),
+		"mantlebackup":          backup.GetName(),
+	}).Set(float64(totalSize))
+
+	return nil
+}
+
+func (r *MantleBackupReconciler) getLargestCompletedUploadPartNum(
+	ctx context.Context,
+	backup *mantlev1.MantleBackup,
+) (int, error) {
+	_, largestPartNum, result := r.listCompletedJobsOfComponent(ctx, backup, labelComponentUploadJob, MantleUploadJobPrefix)
+	if result.ShouldReturn() {
+		_, err := result.ToCtrlResult()
+
+		return -1, err
+	}
+
+	return largestPartNum, nil
 }
 
 func (r *MantleBackupReconciler) handleCompletedUploadJobs(ctx context.Context, backup *mantlev1.MantleBackup) (int, *reconcile.Result) {

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cybozu-go/mantle/internal/ceph"
 	"github.com/cybozu-go/mantle/internal/controller/internal/objectstorage"
 	"github.com/cybozu-go/mantle/internal/controller/internal/reconcile"
+	"github.com/cybozu-go/mantle/internal/controller/metrics"
 	"github.com/cybozu-go/mantle/internal/testutil"
 	"github.com/cybozu-go/mantle/pkg/controller/proto"
 	"github.com/cybozu-go/mantle/test/util"
@@ -116,6 +117,39 @@ func completeJob(ctx SpecContext, jobNamespace, jobName string) {
 	}
 	err := k8sClient.Status().Update(ctx, &job)
 	Expect(err).NotTo(HaveOccurred())
+}
+
+// gatherGaugeValue returns the value of the gauge series matching name and labels,
+// and whether it exists.
+func gatherGaugeValue(name string, labels map[string]string) (float64, bool) {
+	GinkgoHelper()
+
+	mfs, err := runtimemetrics.Registry.Gather()
+	Expect(err).NotTo(HaveOccurred())
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, l := range m.GetLabel() {
+				got[l.GetName()] = l.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+
+					break
+				}
+			}
+			if match {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+
+	return 0, false
 }
 
 var _ = Describe("MantleBackup controller", func() {
@@ -1662,6 +1696,11 @@ var _ = Describe("export and upload", func() {
 		)
 		mbr.ceph = testutil.NewFakeRBD()
 
+		mockObjectStorage := objectstorage.NewMockBucket(mockCtrl)
+		mockObjectStorage.EXPECT().GetSize(gomock.Any(), gomock.Any()).
+			Return(int64(0), nil).AnyTimes()
+		mbr.objectStorageClient = mockObjectStorage
+
 		ns = resMgr.CreateNamespace()
 	})
 
@@ -1872,6 +1911,40 @@ var _ = Describe("export and upload", func() {
 			Entry("snap size = transfer part size", int64(testutil.FakeRBDSnapshotSize), 1),
 			Entry("snap size > transfer part size", int64(testutil.FakeRBDSnapshotSize-1), 2),
 		)
+
+		It("should set backup_exported_diff_size_bytes to the total size of the uploaded parts", func(ctx SpecContext) {
+			const numOfParts = 2
+			const partSize = int64(100)
+			// A transfer part size smaller than the snapshot size splits the backup into 2 parts.
+			mbr.backupTransferPartSize = *resource.NewQuantity(int64(testutil.FakeRBDSnapshotSize-1), resource.BinarySI)
+
+			// Stub GetSize to return a fixed size for every part.
+			mockObjectStorage := objectstorage.NewMockBucket(mockCtrl)
+			mockObjectStorage.EXPECT().GetSize(gomock.Any(), gomock.Any()).
+				Return(partSize, nil).AnyTimes()
+			mbr.objectStorageClient = mockObjectStorage
+
+			target := createAndExportMantleBackup(ctx, mbr, "target", ns, false, false, nil)
+
+			// Complete all export Jobs.
+			for partNum := range numOfParts {
+				completeJob(ctx, MakeExportJobName(target, partNum))
+				runStartExportAndUpload(ctx, target)
+			}
+			// Complete all upload Jobs.
+			for partNum := range numOfParts {
+				completeJob(ctx, MakeUploadJobName(target, partNum))
+				runStartExportAndUpload(ctx, target)
+			}
+
+			value, found := gatherGaugeValue("mantle_backup_exported_diff_size_bytes", map[string]string{
+				"persistentvolumeclaim": target.Spec.PVC,
+				"resource_namespace":    target.GetNamespace(),
+				"mantlebackup":          target.GetName(),
+			})
+			Expect(found).To(BeTrue())
+			Expect(value).To(Equal(float64(numOfParts * partSize)))
+		})
 	})
 })
 
@@ -2623,6 +2696,30 @@ var _ = Describe("import", func() {
 			By("finalizing the backup after the snapshot is already gone")
 			_, err = mbr.finalizeStandalone(ctx, backup).ToCtrlResult()
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should delete the backup_exported_diff_size_bytes metric", func(ctx SpecContext) {
+			backup, err := createMantleBackupUsingDummyPVC(ctx, "target", ns)
+			Expect(err).NotTo(HaveOccurred())
+
+			labels := map[string]string{
+				"persistentvolumeclaim": backup.Spec.PVC,
+				"resource_namespace":    backup.GetNamespace(),
+				"mantlebackup":          backup.GetName(),
+			}
+
+			By("setting the metric for the backup")
+			metrics.BackupExportedDiffSizeBytes.With(labels).Set(1)
+			_, found := gatherGaugeValue("mantle_backup_exported_diff_size_bytes", labels)
+			Expect(found).To(BeTrue())
+
+			By("finalizing the backup")
+			_, err = mbr.finalizeStandalone(ctx, backup).ToCtrlResult()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the metric series is removed")
+			_, found = gatherGaugeValue("mantle_backup_exported_diff_size_bytes", labels)
+			Expect(found).To(BeFalse())
 		})
 	})
 

--- a/internal/controller/metrics/metrics.go
+++ b/internal/controller/metrics/metrics.go
@@ -8,6 +8,15 @@ import (
 const namespace = "mantle"
 
 var (
+	BackupExportedDiffSizeBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "backup_exported_diff_size_bytes",
+			Help:      "The size of the uploaded backup diff data",
+		},
+		[]string{"persistentvolumeclaim", "resource_namespace", "mantlebackup"},
+	)
+
 	BackupConfigInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -29,6 +38,7 @@ var (
 )
 
 func init() {
+	runtimemetrics.Registry.MustRegister(BackupExportedDiffSizeBytes)
 	runtimemetrics.Registry.MustRegister(BackupConfigInfo)
 	runtimemetrics.Registry.MustRegister(BackupDurationSeconds)
 }

--- a/test/e2e/multik8s/misc_test.go
+++ b/test/e2e/multik8s/misc_test.go
@@ -42,6 +42,7 @@ var _ = Describe("metrics tests", func() {
 		Entry(`mantle_backup_duration_seconds_bucket`, `mantle_backup_duration_seconds_bucket`),
 		Entry(`mantle_backup_duration_seconds_sum`, `mantle_backup_duration_seconds_sum`),
 		Entry(`mantle_backup_duration_seconds_count`, `mantle_backup_duration_seconds_count`),
+		Entry(`mantle_backup_exported_diff_size_bytes`, `mantle_backup_exported_diff_size_bytes`),
 	)
 })
 


### PR DESCRIPTION
This PR adds a metric named `mantle_backup_exported_diff_size_bytes`. It is a
Gauge that represents, for a given MantleBackup, the total size in bytes of the
diff parts uploaded to object storage so far. It is exported as soon as the diff
size is known, without waiting for the backup to complete.

So that the value can still be tracked until the backup completes even if the
controller restarts, it is restored from the part sizes in object storage on the
reconcile after a restart. We use a Gauge rather than a Counter because this
restoration can be done with a single Set(). The metric is deleted when the
corresponding MantleBackup is deleted.

The commits are split for ease of review; they will be squashed into one when merged. See the individual commit messages for details.