### PR TITLE
Bump mantle-cluster-wide chart version to 0.4.12

### DIFF
--- a/charts/mantle-cluster-wide/Chart.yaml
+++ b/charts/mantle-cluster-wide/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.0"
+appVersion: "0.12.1"


### PR DESCRIPTION
Use https://github.com/cybozu-go/mantle/releases/tag/v0.12.1