### PR TITLE
Bump mantle chart version to 0.4.12

### DIFF
--- a/charts/mantle/Chart.yaml
+++ b/charts/mantle/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.11
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.0"
+appVersion: "0.12.1"

--- a/charts/mantle/values.yaml
+++ b/charts/mantle/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: ghcr.io/cybozu-go/mantle
   pullPolicy:
   # The image reference: a tag and/or a digest (e.g. "1.2.3@sha256:...").
-  reference: 0.11.3@sha256:64a4080f28b15ff854fe0d54337d0eaadbd70133d5a6129ded37b34e1c1d2f64
+  reference: 0.12.1@sha256:09e1d6369c8ae225f422f795d3d70377a12c4d313791d61f26f6bd4e5adb3c76
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Use https://github.com/cybozu-go/mantle/releases/tag/v0.12.1

Since https://github.com/cybozu-go/mantle/pull/313, we also update `image.reference` in `values.yaml` to [the new tag and digest](https://github.com/cybozu-go/mantle/pkgs/container/mantle/1016918883?tag=0.12.1).

See https://github.com/cybozu-go/mantle/blob/main/RELEASE.md#bump-chart-version