### PR TITLE
feat(controller): limit export data PVC creation

### DIFF
--- a/charts/mantle-cluster-wide/templates/clusterrole.yaml
+++ b/charts/mantle-cluster-wide/templates/clusterrole.yaml
@@ -8,7 +8,6 @@ rules:
       - ""
     resources:
       - configmaps
-      - pods
       - secrets
     verbs:
       - get
@@ -41,6 +40,15 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - deletecollection
+      - get
+      - list
+      - watch
   - apiGroups:
       - batch
     resources:

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -104,7 +104,7 @@ func init() {
 	flags.IntVar(&maxImportJobs, "max-import-jobs", 8,
 		"The maximum number of import jobs that can run simultaneously. If you set this to 0, there is no limit.")
 	flags.IntVar(&maxUploadJobs, "max-upload-jobs", 8,
-		"The maximum number of export jobs that can run simultaneously. If you set this to 0, there is no limit.")
+		"The maximum number of upload jobs that can run simultaneously. If you set this to 0, there is no limit.")
 	flags.IntVar(&maxExportDataPVCs, "max-export-data-pvcs", 16,
 		"The maximum number of export data PVCs that can be created. If you set this to 0, there is no limit.")
 	flags.StringVar(&exportDataStorageClass, "export-data-storage-class", "",

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -57,6 +57,7 @@ var (
 	maxExportJobs                int
 	maxImportJobs                int
 	maxUploadJobs                int
+	maxExportDataPVCs            int
 	exportDataStorageClass       string
 	envSecret                    string
 	objectStorageBucketName      string
@@ -104,6 +105,8 @@ func init() {
 		"The maximum number of import jobs that can run simultaneously. If you set this to 0, there is no limit.")
 	flags.IntVar(&maxUploadJobs, "max-upload-jobs", 8,
 		"The maximum number of export jobs that can run simultaneously. If you set this to 0, there is no limit.")
+	flags.IntVar(&maxExportDataPVCs, "max-export-data-pvcs", 16,
+		"The maximum number of export data PVCs that can be created. If you set this to 0, there is no limit.")
 	flags.StringVar(&exportDataStorageClass, "export-data-storage-class", "",
 		"The storage class of PVCs used to store exported data temporarily.")
 	flags.StringVar(&envSecret, "env-secret", "",
@@ -430,6 +433,7 @@ func setupPrimary(ctx context.Context, mgr manager.Manager, wg *sync.WaitGroup) 
 		Client:                 proto.NewMantleServiceClient(conn),
 		MaxExportJobs:          maxExportJobs,
 		MaxUploadJobs:          maxUploadJobs,
+		MaxExportDataPVCs:      maxExportDataPVCs,
 		ExportDataStorageClass: exportDataStorageClass,
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   verbs:
   - get
@@ -41,6 +40,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - deletecollection
+  - get
+  - list
+  - watch
 - apiGroups:
   - batch
   resources:

--- a/internal/controller/mantlebackup_controller.go
+++ b/internal/controller/mantlebackup_controller.go
@@ -376,6 +376,7 @@ func (r *MantleBackupReconciler) expire(ctx context.Context, backup *mantlev1.Ma
 //+kubebuilder:rbac:groups=mantle.cybozu.io,resources=mantlebackups/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=deletecollection
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
@@ -1326,7 +1327,7 @@ func (r *MantleBackupReconciler) startExport(
 	if ok, result := r.canNewExportJobBeCreated(ctx); result.ShouldReturn() {
 		return -1, result.WrapIfError("failed to check if a new export Job can be created")
 	} else if !ok {
-		// skip to create an export Job
+		// skip creating an export Job
 		return largestCompletedPartNum, nil
 	}
 
@@ -1336,7 +1337,15 @@ func (r *MantleBackupReconciler) startExport(
 		return largestCompletedPartNum, nil
 	}
 
-	if result := r.createOrUpdateExportDataPVC(ctx, targetBackup, largestCompletedPartNum); result.ShouldReturn() {
+	nextPartNum := largestCompletedPartNum + 1
+	if ok, result := r.canNewExportDataPVCBeCreated(ctx, targetBackup, nextPartNum); result.ShouldReturn() {
+		return -1, result.WrapIfError("failed to check if a new export data PVC can be created")
+	} else if !ok {
+		// skip creating an export data PVC and an export Job
+		return largestCompletedPartNum, nil
+	}
+
+	if result := r.createOrUpdateExportDataPVC(ctx, targetBackup, nextPartNum); result.ShouldReturn() {
 		return -1, result.WrapIfError("failed to create or update export data PVC")
 	}
 
@@ -1348,40 +1357,42 @@ func (r *MantleBackupReconciler) startExport(
 }
 
 // handleCompletedJobsOfComponent checks completed {export,upload,import} Jobs and
-// returns the latest completed part number. It also deletes the completed Jobs
-// other than the latest one.
+// returns the latest completed part number. It calls hookPerCompletedPart before
+// deleting each non-latest Job and also for the latest Job, which is kept.
 func (r *MantleBackupReconciler) handleCompletedJobsOfComponent(
 	ctx context.Context,
 	backup *mantlev1.MantleBackup,
 	componentLabel string,
 	componentPrefix string,
-	hookPostJobDeletion *func(partNum int) error,
+	hookPerCompletedPart *func(partNum int, isLatest bool) error,
 ) (int, *reconcile.Result) {
 	completedJobs, largestPartNum, result := r.listCompletedJobsOfComponent(ctx, backup, componentLabel, componentPrefix)
 	if result.ShouldReturn() {
 		return -1, result
 	}
 
-	// Delete the completed Jobs other than the latest one
 	for i := range completedJobs {
 		job := &completedJobs[i]
-		if job.partNum == largestPartNum {
-			continue
+		isLatest := job.partNum == largestPartNum
+
+		if hookPerCompletedPart != nil {
+			if err := (*hookPerCompletedPart)(job.partNum, isLatest); err != nil {
+				return -1, reconcile.Failed("hookPerCompletedPart failed: %w", err)
+			}
 		}
 
-		if err := r.Delete(ctx, &job.job, &client.DeleteOptions{
-			Preconditions: &metav1.Preconditions{
-				UID:             &job.job.UID,
-				ResourceVersion: &job.job.ResourceVersion,
-			},
-			PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
-		}); err != nil {
-			return -1, reconcile.Failed("failed to delete Job: %s: %w", job.job.GetName(), err)
-		}
-
-		if hookPostJobDeletion != nil {
-			if err := (*hookPostJobDeletion)(job.partNum); err != nil {
-				return -1, reconcile.Failed("hookPostJobDeletion failed: %w", err)
+		// Delete the completed Jobs other than the latest one. The latest
+		// completed Job must NOT be deleted because it's used to track the
+		// progress of the component.
+		if !isLatest {
+			if err := r.Delete(ctx, &job.job, &client.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             &job.job.UID,
+					ResourceVersion: &job.job.ResourceVersion,
+				},
+				PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+			}); err != nil {
+				return -1, reconcile.Failed("failed to delete Job: %s: %w", job.job.GetName(), err)
 			}
 		}
 	}
@@ -1471,6 +1482,47 @@ func (r *MantleBackupReconciler) canNewJobBeCreated(ctx context.Context, maxJobs
 
 func (r *MantleBackupReconciler) canNewExportJobBeCreated(ctx context.Context) (bool, *reconcile.Result) {
 	return r.canNewJobBeCreated(ctx, r.primarySettings.MaxExportJobs, labelComponentExportJob)
+}
+
+func (r *MantleBackupReconciler) canNewExportDataPVCBeCreated(
+	ctx context.Context,
+	backup *mantlev1.MantleBackup,
+	partNum int,
+) (bool, *reconcile.Result) {
+	if r.primarySettings.MaxExportDataPVCs == 0 {
+		return true, nil
+	}
+
+	// If the PVC for this part already exists, allow reconciliation to continue
+	// even when the PVC limit is reached so that the corresponding Job can be
+	// created or updated.
+	pvcName := MakeExportDataPVCName(backup, partNum)
+	var pvc corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      pvcName,
+		Namespace: r.managedCephClusterID,
+	}, &pvc); err != nil {
+		if !aerrors.IsNotFound(err) {
+			return false, reconcile.Failed("failed to get export data PVC: %s/%s: %w",
+				r.managedCephClusterID, pvcName, err)
+		}
+	} else {
+		return true, nil
+	}
+
+	var pvcs corev1.PersistentVolumeClaimList
+	if err := r.List(ctx, &pvcs, &client.ListOptions{
+		Namespace: r.managedCephClusterID,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app.kubernetes.io/name":      labelAppNameValue,
+			"app.kubernetes.io/component": labelComponentExportData,
+		}),
+	}); err != nil {
+		return false, reconcile.Failed("failed to list export data PVCs: %w", err)
+	}
+
+	// Count terminating PVCs because their backing PVs can still consume disk space.
+	return len(pvcs.Items) < r.primarySettings.MaxExportDataPVCs, nil
 }
 
 func (r *MantleBackupReconciler) canNewImportJobBeCreated(ctx context.Context) (bool, *reconcile.Result) {
@@ -1651,12 +1703,61 @@ func (r *MantleBackupReconciler) getLargestCompletedUploadPartNum(
 }
 
 func (r *MantleBackupReconciler) handleCompletedUploadJobs(ctx context.Context, backup *mantlev1.MantleBackup) (int, *reconcile.Result) {
-	hook := func(partNum int) error {
-		pvc := corev1.PersistentVolumeClaim{}
-		pvc.SetName(MakeExportDataPVCName(backup, partNum))
-		pvc.SetNamespace(r.managedCephClusterID)
-		if err := r.Delete(ctx, &pvc); err != nil && !aerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete export data PVC: %s/%s: %w", pvc.GetNamespace(), pvc.GetName(), err)
+	cleanUpPartResources := func(partNum int, isLatest bool) error {
+		// Delete the export data PVC of every completed part, including the
+		// latest one. Its data has already been uploaded, so it's no longer
+		// needed. If we kept the PVC of the latest completed part until its
+		// upload Job is deleted, the backup could deadlock when the number of
+		// the export data PVCs reaches MaxExportDataPVCs: the PVC couldn't be
+		// deleted until the upload Job of the next part completes, and the
+		// next part couldn't make progress without a free PVC slot.
+		//
+		// For example, suppose that MaxExportDataPVCs is 2, two multi-part
+		// backups A and B are in progress, and we kept the PVC of the latest
+		// completed part of each backup:
+		//
+		//              | part 0                   | part 1
+		//     ---------+--------------------------+----------------------
+		//     backup A | uploaded (PVC A-0 kept)  | can't create PVC A-1
+		//     backup B | uploaded (PVC B-0 kept)  | can't create PVC B-1
+		//
+		//     existing PVCs: A-0, B-0 (= MaxExportDataPVCs, no free slot)
+		//
+		// In this situation, A would be stuck by the following circular wait,
+		// where "X <- Y" means X waits for Y (the same applies to B):
+		//
+		//     PVC A-0 is deleted
+		//       <- upload Job A-0 is deleted (it's kept while it's the
+		//          latest completed upload Job of A)
+		//       <- upload Job A-1 completes
+		//       <- export Job A-1 completes
+		//       <- PVC A-1 is created
+		//       <- a PVC slot gets free
+		//       <- PVC A-0 or PVC B-0 is deleted (back to the beginning)
+		if err := r.deleteExportDataPVC(ctx, backup, partNum); err != nil {
+			return err
+		}
+
+		// Delete the Pods of the export and upload Jobs of the part. The
+		// pvc-protection controller does not remove the export data PVC deleted
+		// above until all Pods referring to it are deleted, not just terminated.
+		// Keeping those Pods would leave the PVC terminating and occupying a PVC
+		// slot, which could deadlock the backup when the number of export data
+		// PVCs reaches MaxExportDataPVCs. Deleting a non-latest upload Job also
+		// deletes its Pods, but the latest upload Job is kept for progress
+		// tracking, so explicitly delete the Pods of both Jobs for the latest
+		// part.
+		if !isLatest {
+			return nil
+		}
+
+		for _, jobName := range []string{
+			MakeExportJobName(backup, partNum),
+			MakeUploadJobName(backup, partNum),
+		} {
+			if err := r.deletePodsOfJob(ctx, jobName); err != nil {
+				return fmt.Errorf("failed to delete the Pods of the Job of the completed part: %s: %w", jobName, err)
+			}
 		}
 
 		return nil
@@ -1667,8 +1768,68 @@ func (r *MantleBackupReconciler) handleCompletedUploadJobs(ctx context.Context, 
 		backup,
 		labelComponentUploadJob,
 		MantleUploadJobPrefix,
-		&hook,
+		&cleanUpPartResources,
 	)
+}
+
+func (r *MantleBackupReconciler) deleteExportDataPVC(
+	ctx context.Context,
+	backup *mantlev1.MantleBackup,
+	partNum int,
+) error {
+	key := types.NamespacedName{
+		Name:      MakeExportDataPVCName(backup, partNum),
+		Namespace: r.managedCephClusterID,
+	}
+	var pvc corev1.PersistentVolumeClaim
+	if err := r.Get(ctx, key, &pvc); err != nil {
+		if aerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get export data PVC: %s: %w", key, err)
+	}
+	if !pvc.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	if err := r.Delete(ctx, &pvc, &client.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &pvc.UID,
+			ResourceVersion: &pvc.ResourceVersion,
+		},
+	}); err != nil && !aerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete export data PVC: %s: %w", key, err)
+	}
+
+	return nil
+}
+
+func (r *MantleBackupReconciler) deletePodsOfJob(ctx context.Context, jobName string) error {
+	// List the Pods first to avoid sending an unnecessary DeleteAllOf write
+	// request to kube-apiserver when there are no Pods to delete.
+	listOptions := []client.ListOption{
+		client.InNamespace(r.managedCephClusterID),
+		client.MatchingLabels{batchv1.JobNameLabel: jobName},
+	}
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods, listOptions...); err != nil {
+		return fmt.Errorf("failed to list Pods of Job: %s: %w", jobName, err)
+	}
+	if len(pods.Items) == 0 {
+		return nil
+	}
+
+	if err := r.DeleteAllOf(
+		ctx,
+		&corev1.Pod{},
+		client.InNamespace(r.managedCephClusterID),
+		client.MatchingLabels{batchv1.JobNameLabel: jobName},
+	); err != nil {
+		return fmt.Errorf("failed to delete Pods of Job: %s: %w", jobName, err)
+	}
+
+	return nil
 }
 
 func calculateExportDataPVCSize(transferPartSize *resource.Quantity) (*resource.Quantity, error) {
@@ -1700,7 +1861,7 @@ func calculateExportDataPVCSize(transferPartSize *resource.Quantity) (*resource.
 func (r *MantleBackupReconciler) createOrUpdateExportDataPVC(
 	ctx context.Context,
 	target *mantlev1.MantleBackup,
-	largestCompletedPartNum int,
+	partNum int,
 ) *reconcile.Result {
 	var targetPVC corev1.PersistentVolumeClaim
 	if err := json.Unmarshal([]byte(target.Status.PVCManifest), &targetPVC); err != nil {
@@ -1714,7 +1875,7 @@ func (r *MantleBackupReconciler) createOrUpdateExportDataPVC(
 	}
 
 	var pvc corev1.PersistentVolumeClaim
-	pvc.SetName(MakeExportDataPVCName(target, largestCompletedPartNum+1))
+	pvc.SetName(MakeExportDataPVCName(target, partNum))
 	pvc.SetNamespace(r.managedCephClusterID)
 	if _, err = ctrl.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
 		labels := pvc.GetLabels()

--- a/internal/controller/mantlebackup_controller_test.go
+++ b/internal/controller/mantlebackup_controller_test.go
@@ -1666,6 +1666,81 @@ var _ = Describe("export and upload", func() {
 		}, "3s", "1s").Should(Succeed())
 	}
 
+	getExportDataPVC := func(
+		ctx SpecContext,
+		ns string,
+		backup *mantlev1.MantleBackup,
+		partNum int,
+	) (corev1.PersistentVolumeClaim, error) {
+		var pvc corev1.PersistentVolumeClaim
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      MakeExportDataPVCName(backup, partNum),
+			Namespace: ns,
+		}, &pvc)
+
+		return pvc, err
+	}
+
+	getNumOfExportDataPVCs := func(ctx SpecContext, ns string) (int, error) {
+		var pvcs corev1.PersistentVolumeClaimList
+		err := k8sClient.List(ctx, &pvcs, &client.ListOptions{
+			Namespace: ns,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"app.kubernetes.io/name":      labelAppNameValue,
+				"app.kubernetes.io/component": labelComponentExportData,
+			}),
+		})
+
+		return len(pvcs.Items), err
+	}
+
+	// waitExportDataPVCTerminating waits until the export data PVC is deleted,
+	// i.e., it has a deletion timestamp.
+	waitExportDataPVCTerminating := func(ctx SpecContext, ns string, backup *mantlev1.MantleBackup, partNum int) {
+		GinkgoHelper()
+
+		Eventually(ctx, func(g Gomega) error {
+			pvc, err := getExportDataPVC(ctx, ns, backup, partNum)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(pvc.GetDeletionTimestamp().IsZero()).To(BeFalse())
+
+			return nil
+		}).Should(Succeed())
+	}
+
+	// completeExportDataPVCDeletion removes the PVC protection finalizer of the
+	// export data PVC so envtest completes its deletion, and waits until the PVC
+	// is completely removed.
+	completeExportDataPVCDeletion := func(ctx SpecContext, ns string, backup *mantlev1.MantleBackup, partNum int) {
+		GinkgoHelper()
+
+		Eventually(ctx, func(g Gomega) error {
+			pvc, err := getExportDataPVC(ctx, ns, backup, partNum)
+			if aerrors.IsNotFound(err) {
+				return nil
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			pvc.SetFinalizers(nil)
+
+			return k8sClient.Update(ctx, &pvc)
+		}).Should(Succeed())
+
+		Eventually(ctx, func(g Gomega) error {
+			_, err := getExportDataPVC(ctx, ns, backup, partNum)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(aerrors.IsNotFound(err)).To(BeTrue())
+
+			return nil
+		}).Should(Succeed())
+	}
+
+	waitPVCDeletedAndRemoveFinalizers := func(ctx SpecContext, ns string, backup *mantlev1.MantleBackup, partNum int) {
+		GinkgoHelper()
+
+		waitExportDataPVCTerminating(ctx, ns, backup, partNum)
+		completeExportDataPVCDeletion(ctx, ns, backup, partNum)
+	}
+
 	BeforeEach(func() {
 		var t reporter
 		mockCtrl = gomock.NewController(t)
@@ -1796,6 +1871,191 @@ var _ = Describe("export and upload", func() {
 
 				return nil
 			}).Should(Succeed())
+		})
+
+		It("should throttle export data PVCs correctly", func(ctx SpecContext) {
+			// Allow unlimited export Jobs so that only the export data PVC
+			// limit throttles the backups.
+			mbr.primarySettings.MaxExportJobs = 0
+			mbr.primarySettings.MaxExportDataPVCs = 1
+
+			// Create 3 different MantleBackups and start exporting each of them.
+			backups := make([]*mantlev1.MantleBackup, 0, 3)
+			for i := range 3 {
+				backup := createAndExportMantleBackup(ctx, mbr, fmt.Sprintf("target1-%d", i), ns, false, false, nil)
+				backups = append(backups, backup)
+			}
+
+			// Only 1 export data PVC (of backups[0], the first exported one)
+			// should be created due to MaxExportDataPVCs=1.
+			Consistently(ctx, func(g Gomega) error {
+				numPVCs, err := getNumOfExportDataPVCs(ctx, nsController)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numPVCs).To(Equal(1))
+
+				return nil
+			}, "1s").Should(Succeed())
+
+			// Delete the sole export data PVC. It remains terminating because
+			// of the pvc-protection finalizer, which nothing removes in envtest.
+			pvc, err := getExportDataPVC(ctx, nsController, backups[0], 0)
+			Expect(err).NotTo(HaveOccurred())
+			err = k8sClient.Delete(ctx, &pvc)
+			Expect(err).NotTo(HaveOccurred())
+			waitExportDataPVCTerminating(ctx, nsController, backups[0], 0)
+
+			// Reconcile backups[1]. The terminating PVC still occupies the
+			// only PVC slot, so no new PVC should be created.
+			runStartExportAndUpload(ctx, backups[1])
+			Consistently(ctx, func(g Gomega) error {
+				numPVCs, err := getNumOfExportDataPVCs(ctx, nsController)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numPVCs).To(Equal(1))
+
+				return nil
+			}, "1s").Should(Succeed())
+
+			// Remove the finalizer of the terminating PVC and wait until it's
+			// completely removed to free the PVC slot.
+			completeExportDataPVCDeletion(ctx, nsController, backups[0], 0)
+
+			// Reconcile backups[1] again. Now it should be able to create its
+			// export data PVC, and the total number of the PVCs should get
+			// back to 1.
+			runStartExportAndUpload(ctx, backups[1])
+			Eventually(ctx, func(g Gomega) error {
+				pvc, err := getExportDataPVC(ctx, nsController, backups[1], 0)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pvc.GetDeletionTimestamp().IsZero()).To(BeTrue())
+
+				numPVCs, err := getNumOfExportDataPVCs(ctx, nsController)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numPVCs).To(Equal(1))
+
+				return nil
+			}).Should(Succeed())
+
+			// Make sure that another mantle-controller existing in a different
+			// namespace can create an export data PVC, i.e., the PVCs are
+			// counted per namespace.
+			nsController2 := resMgr.CreateNamespace()
+			mbr2 := NewMantleBackupReconciler(
+				k8sClient,
+				scheme.Scheme,
+				nsController2,
+				RolePrimary,
+				&PrimarySettings{
+					Client:                 grpcClient,
+					ExportDataStorageClass: resMgr.StorageClassName,
+					MaxExportJobs:          0,
+					MaxExportDataPVCs:      1,
+				},
+				nil,
+				"dummy image",
+				"",
+				nil,
+				nil,
+				resource.MustParse("1Gi"),
+			)
+			mbr2.ceph = testutil.NewFakeRBD()
+			ns2 := resMgr.CreateNamespace()
+			createAndExportMantleBackup(ctx, mbr2, "target2", ns2, false, false, nil)
+			Eventually(ctx, func(g Gomega) error {
+				numPVCs, err := getNumOfExportDataPVCs(ctx, nsController2)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numPVCs).To(Equal(1))
+
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should not throttle export data PVCs when the limit is zero", func(ctx SpecContext) {
+			mbr.primarySettings.MaxExportJobs = 0
+			mbr.primarySettings.MaxExportDataPVCs = 0
+
+			for i := range 3 {
+				createAndExportMantleBackup(ctx, mbr, fmt.Sprintf("target-%d", i), ns, false, false, nil)
+			}
+
+			Eventually(ctx, func(g Gomega) error {
+				numPVCs, err := getNumOfExportDataPVCs(ctx, nsController)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(numPVCs).To(Equal(3))
+
+				return nil
+			}).Should(Succeed())
+		})
+
+		It("should complete a multi-part backup even when MaxExportDataPVCs is 1", func(ctx SpecContext) {
+			mbr.primarySettings.MaxExportJobs = 0
+			mbr.primarySettings.MaxExportDataPVCs = 1
+			mbr.backupTransferPartSize = *resource.NewQuantity(int64(testutil.FakeRBDSnapshotSize)-1, resource.BinarySI)
+
+			createDummyPodOfJob := func(jobName string) {
+				GinkgoHelper()
+
+				pod := corev1.Pod{}
+				pod.SetName(jobName)
+				pod.SetNamespace(nsController)
+				pod.SetLabels(map[string]string{batchv1.JobNameLabel: jobName})
+				pod.Spec.Containers = []corev1.Container{{Name: "dummy", Image: "dummy"}}
+				err := k8sClient.Create(ctx, &pod)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			waitPodsOfJobDeleted := func(jobName string) {
+				GinkgoHelper()
+
+				Eventually(ctx, func(g Gomega) error {
+					var pods corev1.PodList
+					err := k8sClient.List(ctx, &pods, &client.ListOptions{
+						Namespace: nsController,
+						LabelSelector: labels.SelectorFromSet(map[string]string{
+							batchv1.JobNameLabel: jobName,
+						}),
+					})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(pods.Items).To(BeEmpty())
+
+					return nil
+				}).Should(Succeed())
+			}
+
+			// The backup is split into 2 parts because the transfer part size is
+			// slightly smaller than the snapshot size.
+			target := createAndExportMantleBackup(ctx, mbr, "target-multi-part", ns, false, false, nil)
+
+			// Create dummy Pods that pretend to belong to the export and upload
+			// Jobs of part 0, because envtest doesn't run the Job controller and
+			// thus no Pods are created for the Jobs.
+			createDummyPodOfJob(MakeExportJobName(target, 0))
+			createDummyPodOfJob(MakeUploadJobName(target, 0))
+
+			// Complete the export and upload Jobs of part 0.
+			completeJob(ctx, MakeExportJobName(target, 0))
+			runStartExportAndUpload(ctx, target)
+			completeJob(ctx, MakeUploadJobName(target, 0))
+			runStartExportAndUpload(ctx, target)
+
+			// The Pods of the export and upload Jobs of part 0 should be deleted
+			// so that the pvc-protection controller can remove the PVC of part 0.
+			waitPodsOfJobDeleted(MakeExportJobName(target, 0))
+			waitPodsOfJobDeleted(MakeUploadJobName(target, 0))
+
+			// The PVC of part 0 should be deleted as soon as the upload Job of
+			// part 0 completes. Otherwise, the backup would deadlock: the PVC of
+			// part 1 could not be created due to MaxExportDataPVCs=1, so the
+			// upload Job of part 1 would never complete, which in turn would keep
+			// the PVC of part 0 undeleted.
+			waitPVCDeletedAndRemoveFinalizers(ctx, nsController, target, 0)
+
+			// Make sure part 1 can proceed and complete.
+			runStartExportAndUpload(ctx, target)
+			completeJob(ctx, MakeExportJobName(target, 1))
+			runStartExportAndUpload(ctx, target)
+			completeJob(ctx, MakeUploadJobName(target, 1))
+			runStartExportAndUpload(ctx, target)
+			waitPVCDeletedAndRemoveFinalizers(ctx, nsController, target, 1)
 		})
 
 		DescribeTable(

--- a/internal/controller/replication.go
+++ b/internal/controller/replication.go
@@ -29,6 +29,7 @@ type PrimarySettings struct {
 	Client                 proto.MantleServiceClient
 	MaxExportJobs          int
 	MaxUploadJobs          int
+	MaxExportDataPVCs      int
 	ExportDataStorageClass string
 }
 

--- a/test/e2e/multik8s/misc_test.go
+++ b/test/e2e/multik8s/misc_test.go
@@ -147,6 +147,37 @@ var _ = Describe("miscellaneous tests", func() {
 		EnsureCorrectRestoration(SecondaryK8sCluster, ctx, namespace, backupName2, restoreName2, writtenDataHash2)
 	})
 
+	It("should complete a multi-part backup even when max-export-data-pvcs is 1", func(ctx SpecContext) {
+		namespace := util.GetUniqueName("ns-")
+		pvcName := util.GetUniqueName("pvc-")
+		backupName := util.GetUniqueName("mb-")
+
+		SetupEnvironment(namespace)
+
+		maxExportDataPVCs := 1
+		ChangeMaxExportDataPVCs(&maxExportDataPVCs)
+		defer ChangeMaxExportDataPVCs(nil)
+
+		CreatePVC(ctx, PrimaryK8sCluster, namespace, pvcName)
+		_ = WriteRandomDataToPV(ctx, PrimaryK8sCluster, namespace, pvcName)
+
+		// Make sure the backup will be split into multiple parts.
+		pvc, err := GetPVC(PrimaryK8sCluster, namespace, pvcName)
+		Expect(err).NotTo(HaveOccurred())
+		numParts, err := GetNumberOfBackupParts(pvc.Spec.Resources.Requests.Storage())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(numParts).To(BeNumerically(">", 1))
+
+		CreateMantleBackup(PrimaryK8sCluster, namespace, pvcName, backupName)
+		WaitMantleBackupSynced(namespace, backupName)
+
+		primaryMB, err := GetMB(PrimaryK8sCluster, namespace, backupName)
+		Expect(err).NotTo(HaveOccurred())
+		secondaryMB, err := GetMB(SecondaryK8sCluster, namespace, backupName)
+		Expect(err).NotTo(HaveOccurred())
+		WaitTemporaryResourcesDeleted(ctx, primaryMB, secondaryMB)
+	})
+
 	It("should succeed in backup even if part=0 upload Job completes after part=1 upload Job does",
 		func(ctx SpecContext) {
 			namespace := util.GetUniqueName("ns-")

--- a/test/e2e/multik8s/testutil/util.go
+++ b/test/e2e/multik8s/testutil/util.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1044,30 +1045,86 @@ func GetNumberOfBackupParts(snapshotSize *resource.Quantity) (int, error) {
 	return int(expectedNumOfParts), nil
 }
 
-func ChangeBackupTransferPartSize(size string) {
+// changeMantleControllerArg sets the CLI argument named flag (e.g.,
+// "--max-export-data-pvcs") of the mantle-controller in the primary cluster to
+// value. If value is nil, the argument is removed so that the controller falls
+// back to its default value. It waits until the rollout completes, so the new
+// controller Pod is guaranteed to run with the updated arguments when this
+// function returns.
+func changeMantleControllerArg(flag string, value *string) {
 	GinkgoHelper()
 
 	deployMC, err := GetDeploy(PrimaryK8sCluster, CephClusterNamespace, MantleControllerDeployName)
 	Expect(err).NotTo(HaveOccurred())
 
 	args := deployMC.Spec.Template.Spec.Containers[0].Args
-	backupTransferPartSizeIndex := slices.IndexFunc(
+	argIndex := slices.IndexFunc(
 		args,
-		func(arg string) bool { return strings.HasPrefix(arg, "--backup-transfer-part-size=") },
+		func(arg string) bool { return strings.HasPrefix(arg, flag+"=") },
 	)
-	Expect(backupTransferPartSizeIndex).NotTo(Equal(-1))
+
+	var patch string
+	switch {
+	case value == nil && argIndex == -1:
+		return
+	case value == nil:
+		patch = fmt.Sprintf(
+			`[{"op": "remove", "path": "/spec/template/spec/containers/0/args/%d"}]`,
+			argIndex,
+		)
+	case argIndex == -1:
+		patch = fmt.Sprintf(
+			`[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", `+
+				`"value":"%s=%s"}]`,
+			flag,
+			*value,
+		)
+	default:
+		patch = fmt.Sprintf(
+			`[{"op": "replace", "path": "/spec/template/spec/containers/0/args/%d", `+
+				`"value":"%s=%s"}]`,
+			argIndex,
+			flag,
+			*value,
+		)
+	}
 
 	_, _, err = Kubectl(
 		PrimaryK8sCluster, nil,
-		"patch", "deploy", "-n", CephClusterNamespace, MantleControllerDeployName, "--type=json",
-		fmt.Sprintf(
-			`-p=[{"op": "replace", "path": "/spec/template/spec/containers/0/args/%d", `+
-				`"value":"--backup-transfer-part-size=%s"}]`,
-			backupTransferPartSizeIndex,
-			size,
-		),
+		"patch", "deploy", "-n", CephClusterNamespace, MantleControllerDeployName, "--type=json", "-p="+patch,
 	)
 	Expect(err).NotTo(HaveOccurred())
+
+	_, _, err = Kubectl(
+		PrimaryK8sCluster, nil,
+		"rollout", "status", "-n", CephClusterNamespace,
+		"deploy/"+MantleControllerDeployName, "--timeout=3m",
+	)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// ChangeBackupTransferPartSize sets --backup-transfer-part-size of the
+// mantle-controller in the primary cluster to size, and waits until the
+// rollout completes.
+func ChangeBackupTransferPartSize(size string) {
+	GinkgoHelper()
+
+	changeMantleControllerArg("--backup-transfer-part-size", &size)
+}
+
+// ChangeMaxExportDataPVCs sets --max-export-data-pvcs of the mantle-controller
+// in the primary cluster to count. If count is nil, the argument is removed so
+// that the controller falls back to its default value. It waits until the
+// rollout completes.
+func ChangeMaxExportDataPVCs(count *int) {
+	GinkgoHelper()
+
+	var value *string
+	if count != nil {
+		v := strconv.Itoa(*count)
+		value = &v
+	}
+	changeMantleControllerArg("--max-export-data-pvcs", value)
 }
 
 func ChangeComponentJobScript(


### PR DESCRIPTION
Add a primary controller flag and reconciler throttle for export data PVC creation. Cover namespace scoping and unlimited mode in controller tests.