### PR TITLE
test(controller): fix flaky restore unit test

### DIFF
--- a/internal/controller/mantlerestore_controller_test.go
+++ b/internal/controller/mantlerestore_controller_test.go
@@ -332,10 +332,8 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPVC() {
 		err := test.reconciler.createRestoringPVCIfNotExists(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(ctx, func(g Gomega) {
-			err = k8sClient.Get(ctx, client.ObjectKey{Name: restore.Name, Namespace: test.tenantNamespace}, &pvc)
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
+		waitForObjectToBeCached(ctx, test.reconciler.client,
+			client.ObjectKey{Name: restore.Name, Namespace: test.tenantNamespace}, &pvc)
 
 		err = test.reconciler.deleteRestoringPVC(ctx, restore)
 		Expect(err).NotTo(HaveOccurred())
@@ -367,6 +365,9 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPVC() {
 		err := test.reconciler.createRestoringPVCIfNotExists(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
+		waitForObjectToBeCached(ctx, test.reconciler.client,
+			client.ObjectKey{Name: restore.Name, Namespace: test.tenantNamespace}, &pvc)
+
 		err = test.reconciler.deleteRestoringPVC(ctx, restoreDifferent)
 		Expect(err).To(HaveOccurred())
 
@@ -396,10 +397,8 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPV() {
 		err := test.reconciler.createRestoringPVIfNotExists(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(ctx, func(g Gomega) {
-			err = k8sClient.Get(ctx, client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
+		waitForObjectToBeCached(ctx, test.reconciler.client,
+			client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
 
 		err = test.reconciler.deleteRestoringPV(ctx, restore)
 		Expect(err).NotTo(HaveOccurred())
@@ -431,11 +430,8 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPV() {
 		err := test.reconciler.createRestoringPVIfNotExists(ctx, restore, test.backup)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Make sure the client cache stores the restoring PV.
-		Eventually(func(g Gomega) {
-			err = k8sClient.Get(ctx, client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
-			g.Expect(err).NotTo(HaveOccurred())
-		}).Should(Succeed())
+		waitForObjectToBeCached(ctx, test.reconciler.client,
+			client.ObjectKey{Name: test.reconciler.restoringPVName(restore)}, &pv)
 
 		err = test.reconciler.deleteRestoringPV(ctx, restoreDifferent)
 		Expect(err).To(HaveOccurred())
@@ -451,6 +447,17 @@ func (test *mantleRestoreControllerUnitTest) testDeleteRestoringPV() {
 		err = test.reconciler.deleteRestoringPV(ctx, restore)
 		Expect(err).NotTo(HaveOccurred())
 	})
+}
+
+// waitForObjectToBeCached waits until the given (cached) client observes the
+// object. deleteRestoringPVC and deleteRestoringPV read objects through the
+// reconciler's cached client and return nil on NotFound, so tests must wait
+// for the cache to catch up before calling them.
+func waitForObjectToBeCached(ctx context.Context, c client.Client, key client.ObjectKey, obj client.Object) {
+	GinkgoHelper()
+	Eventually(ctx, func(g Gomega) {
+		g.Expect(c.Get(ctx, key, obj)).NotTo(HaveOccurred())
+	}).Should(Succeed())
 }
 
 // helper function to get MantleRestore object.


### PR DESCRIPTION
test(controller): fix flaky restore unit tests

The deleteRestoringPVC and deleteRestoringPV tests called these
functions right after creating the PVC/PV via the API server. Both
functions read the object through the manager's cached client and
return nil on NotFound, so they could miss the object and skip the
deletion before the cache caught up, failing the tests
intermittently.

Introduce the waitForObjectToBeCached helper and use it to wait until
the cached client observes the PVC/PV before calling
deleteRestoringPVC/deleteRestoringPV.
