### PR TITLE
fix osd CLBO on e2e

### DIFF
--- a/test/e2e/testdata/values-cluster.yaml
+++ b/test/e2e/testdata/values-cluster.yaml
@@ -25,6 +25,8 @@ cephClusterSpec:
   crashCollector:
     disable: true
   storage:
+    useAllNodes: false
+    useAllDevices: false
     storageClassDeviceSets:
       - name: set1
         count: 1


### PR DESCRIPTION
The loop device was sometimes initialized twice, causing the OSD to become CLBO. We reviewed the settings to avoid this unnecessary initialization.